### PR TITLE
Also try to use python-libdiscid

### DIFF
--- a/picard/disc.py
+++ b/picard/disc.py
@@ -19,8 +19,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-# use python-discid (http://python-discid.readthedocs.org/en/latest/)
-import discid
+try:
+    # use python-libdiscid (http://pythonhosted.org/python-libdiscid/)
+    from libdiscid.compat import discid
+except ImportError:
+    # use python-discid (http://python-discid.readthedocs.org/en/latest/)
+    import discid
 import traceback
 from PyQt4 import QtCore
 from picard import log

--- a/picard/util/cdrom.py
+++ b/picard/util/cdrom.py
@@ -24,7 +24,10 @@ from picard.util import uniqify
 
 DEFAULT_DRIVES = []
 try:
-    import discid
+    try:
+        from libdiscid.compat import discid
+    except ImportError:
+        import discid
     device = discid.get_default_device()
     if device:
         DEFAULT_DRIVES = [device]


### PR DESCRIPTION
python-libdiscid is another libdiscid binding that also provides a python-discid
compatible interface in libdiscid.compat.discid.

The order of libdiscid and discid can be reversed of course, but then also OSError should be catched, i.e.

``` python
try:
    import discid
except (ImportError, OSError):
    from libdiscid.compat import discid
```
