### PR TITLE
Add platform-specific note to $datetime

### DIFF
--- a/picard/script.py
+++ b/picard/script.py
@@ -1722,7 +1722,12 @@ def func_slice(parser, multi, start_index, end_index, separator=MULTI_VALUED_JOI
 Returns the current date and time in the specified `format`, which is based on
     the standard Python `strftime` [format codes](https://strftime.org/). If no
     `format` is specified the date/time will be returned in the form
-    `2020-02-05 14:26:32`."""
+    `2020-02-05 14:26:32`.
+Note: Platform-specific formatting codes should be avoided to help ensure the
+    portability of scripts across the different platforms.  These codes include:
+    remove zero-padding (e.g. `%-d` and `%-m` on Linux or macOS, and their
+    equivalent `%#d` and `%#m` on Windows); element length specifiers (e.g.
+    `%3Y`); and hanging '%' at the end of the format string."""
 ))
 def func_datetime(parser, format=None):
     """Return the current date and time as a string.


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**: Added note to `$datetime` documentation to discourage the use of platform-specific formatting codes.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The Python `strftime` method (used by the Picard `$datetime` scripting function) does not provide consistent results across OS platforms and Python versions.  This could lead to user scripts developed on one platform breaking on another.  Something should be added to the documentation to make the users aware of this issue and to try to avoid using platform-specific formatting codes.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Added note to `$datetime` documentation to discourage the use of platform-specific formatting codes.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
