### PR TITLE
Avoid update_item in File.update_acoustid

### DIFF
--- a/picard/file.py
+++ b/picard/file.py
@@ -655,8 +655,8 @@ class File(QtCore.QObject, Item):
                 self.clear_pending()
                 self.parent.remove_file(self, new_album=new_album)
             self.parent = parent
-            self.parent.add_file(self, new_album=new_album)
             self.acoustid_update()
+            self.parent.add_file(self, new_album=new_album)
             return True
         else:
             return False
@@ -690,7 +690,6 @@ class File(QtCore.QObject, Item):
             if not recording_id:
                 recording_id = self.metadata['musicbrainz_recordingid']
         self.tagger.acoustidmanager.update(self, recording_id)
-        self.update_item()
 
     @classmethod
     def supports_tag(cls, name):


### PR DESCRIPTION
When moving ensure update_acoustid happens before calling parent.add_file but after parent has been changed. This ensures the fingerprint status is correct when the parent updates and makes another update afterwards unnecessary.
