### PR TITLE
3 tier matching fixes

### DIFF
--- a/picard/cluster.py
+++ b/picard/cluster.py
@@ -328,8 +328,12 @@ class Cluster(FileList):
         )
         if DebugOpt.MATCHING.enabled:
             for i, m in enumerate(all_matches[:5]):
-                title = m.release.get('title', '?') if m.release else '?'
-                log.debug("  #%d sim=%.4f  %r", i + 1, m.similarity, title)
+                title = '?'
+                mbid = '?'
+                if m.release:
+                    title = m.release.get('title', '?')
+                    mbid = m.release.get('id', '?')
+                log.debug("  #%d sim=%.4f  %r (%s)", i + 1, m.similarity, title, mbid)
 
         no_match = SimMatchRelease(similarity=-1, release=None)
         best_match = find_best_match_with_margin(

--- a/picard/file.py
+++ b/picard/file.py
@@ -1085,8 +1085,12 @@ class File(MetadataItem):
         )
         if DebugOpt.MATCHING.enabled:
             for i, m in enumerate(all_matches[:5]):
-                title = m.track.get('title', '?') if m.track else '?'
-                log.debug("  #%d sim=%.4f  %r", i + 1, m.similarity, title)
+                title = '?'
+                mbid = '?'
+                if m.track:
+                    title = m.track.get('title', '?')
+                    mbid = m.track.get('id', '?')
+                log.debug("  #%d sim=%.4f  %r (%s)", i + 1, m.similarity, title, mbid)
 
         no_match = SimMatchTrack(similarity=-1, releasegroup=None, release=None, track=None)
         best_match = find_best_match_with_margin(

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -162,9 +162,11 @@ class ReleaseMatchParts:
 # Type for the tiered weights dict structure
 TieredWeights: TypeAlias = dict[str, dict[str, int]]
 
-# Similarity keys that are track-level (scored in compare_to_track, not in
-# compare_to_release_parts). Keep in sync with compare_to_track.
-_TRACK_SIMILARITY_KEYS = frozenset({'title', 'artist', 'length'})
+# Similarity keys that are on release-level. Keep in sync with compare_to_release_parts.
+_RELEASE_WEIGHT_KEYS = {
+    'similarity': frozenset({'album', 'albumartist', 'date', 'totaltracks', 'totalalbumtracks'}),
+    'preferences': frozenset({'format', 'releasecountry', 'releasetype'}),
+}
 
 
 def _catno_label_score(file_catno, file_label, release_label_info):
@@ -547,7 +549,7 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
                         score = 1.0 if file_isrc in track_isrcs else 0.0
                         track_parts.identifiers.append((score, id_w['isrc']))
 
-            # Track-level similarity signals (see _TRACK_SIMILARITY_KEYS)
+            # Track-level similarity signals
             if 'title' in self and 'title' in sim_w:
                 a = self['title']
                 b = track.get('title', '')
@@ -578,8 +580,9 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
             if not releases:
                 config = get_config()
                 score = dict(config.setting['release_type_scores']).get('Other', 0.5)
-                track_parts.preferences.append((score, _get_total_release_weight(weights)))
-                sim = linear_combination_of_weights(track_parts.all_parts) * search_score
+                release_parts = _get_weighted_release_parts(weights, score)
+                track_parts = track_parts.merged_with(release_parts)
+                sim = track_parts.combine_tiers() * search_score
                 return SimMatchTrack(similarity=sim, releasegroup=None, release=None, track=track)
 
         result = SimMatchTrack(similarity=-1, releasegroup=None, release=None, track=None)
@@ -930,17 +933,18 @@ class MultiMetadataProxy:
         return self.__read('__repr__')
 
 
-def _get_total_release_weight(weights):
+def _get_weighted_release_parts(weights: dict[str, dict[str, int]], score: float) -> ReleaseMatchParts:
     """Sum of all release-level weights (used as fallback when no releases are available).
 
-    Excludes track-level similarity keys (see _TRACK_SIMILARITY_KEYS).
+    Consider only release-level similarity keys (see _RELEASE_WEIGHT_KEYS).
     """
-    total = 0
-    for tier_weights in weights.values():
-        for key, weight in tier_weights.items():
-            if key not in _TRACK_SIMILARITY_KEYS:
-                total += weight
-    return total
+    result = ReleaseMatchParts()
+    for tier in {'similarity', 'preferences'}:
+        if tier in weights:
+            keys = _RELEASE_WEIGHT_KEYS.get(tier, [])
+            total_weight = sum(value for key, value in weights[tier].items() if key in keys)
+            getattr(result, tier).append((score, total_weight))
+    return result
 
 
 album_metadata_processors = PluginFunctions(label='album_metadata_processors')

--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -433,8 +433,8 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         # Tier 1: Identifiers — exact matches, cheap to compute
         if 'barcode' in id_w:
             file_barcode = self.get('barcode', '')
-            if file_barcode:
-                release_barcode = release.get('barcode', '')
+            if file_barcode and 'barcode' in release:
+                release_barcode = release['barcode']
                 if compare_barcodes(file_barcode, release_barcode):
                     result.identifiers.append((1.0, id_w['barcode']))
                 else:
@@ -442,8 +442,8 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
 
         if 'catno' in id_w:
             file_catno = self.get('catalognumber', '').strip().lower()
-            if file_catno:
-                release_label_info = release.get('label-info', [])
+            if file_catno and 'label-info' in release:
+                release_label_info = release['label-info']
                 if release_label_info:
                     file_label = self.get('label', '').strip().lower()
                     score = _catno_label_score(file_catno, file_label, release_label_info)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -45,6 +45,7 @@ from picard.metadata import (
     Metadata,
     MultiMetadataProxy,
     ReleaseMatchParts,
+    _get_weighted_release_parts,
     trackcount_score,
     weights_from_preferred_countries,
     weights_from_preferred_formats,
@@ -756,6 +757,17 @@ class CommonTests:
             self.assertEqual(parts[0], (0.75, 123))
             weights_from_release_type_scores(parts, release, {}, 123)
             self.assertEqual(parts[1], (0.5, 123))
+
+        def test_get_weighted_release_parts(self):
+            weights = {
+                'similarity': {'album': 10, 'totaltracks': 5, 'title': 12},
+                'preferences': {'releasecountry': 5, 'isvideo': 2},
+            }
+            parts = _get_weighted_release_parts(weights, 0.5)
+            self.assertIsInstance(parts, ReleaseMatchParts)
+            self.assertEqual(parts.identifiers, [])
+            self.assertEqual(parts.similarity, [(0.5, 15)])
+            self.assertEqual(parts.preferences, [(0.5, 5)])
 
         def test_preferred_countries(self):
             release = load_test_json('release.json')


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [CONTRIBUTING.md](https://github.com/metabrainz/picard/blob/master/CONTRIBUTING.md).
-->

<!-- pyml disable-next-line first-line-heading-->
## Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

## Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

@zas This is addressing the issues I identified with recording lookups. Mainly recording lookups without releases scored really low (often at around 0.2 or lower, even for otherwise good matches). But standalone recording lookups remained uneffected . There are two main changes here:

1. The main cause for the low scores was, that the web service does not include `barcode` and `label-info` for recording lookups. This is unfortunate, and we should probably ask the server team to include these identifiers. But since barcode and catno are considered identifiers, and cause a significant score penalty if absent, I changed the code to not consider these weights, if the webservice is not even returning the field. This change solves the big difference between the scores for recordings with and without releases.
2. The new code basically reused the approach implemented in https://github.com/metabrainz/picard/pull/2348/changes/a2f3f25de3800e5955b7fb97241ff0ec115b1f00 to introduce a assumed average release score for standaline recordings based on the "other" preferred type and release weights. But this weighting did consider all "non-track" fields into a single preference score and did not consider the different tiers.


## Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->



## AI Usage

<!--
    Update the checkbox with an [x] for the level of AI contribution to the changes you are making.
-->

In accordance with the AI use policy portion of the [MetaBrainz Contribution Guidelines](https://github.com/metabrainz/guidelines/blob/master/README.md), the level of AI/LLM use in the development of this Pull Request is:

* [ ] No AI/LLM use
* [x] Minimal use (e.g. autocompletion)
* [ ] Moderate use (e.g. suggestions regarding code fragments)
* [ ] Significant use (e.g. code structure, tests development, etc.)
* [ ] Primarily AI developed
* [ ] Other (please specify below)

<!--
    What portions of the code were developed using AI and/or how was AI used in preparing this PR?
-->



## Action

Additional actions required:
* [ ] Update Picard [documentation](https://github.com/metabrainz/picard-docs) (please include a reference to this PR)
* [ ] Other (please specify below)

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
