### PR TITLE
Support comparing multiple file ISRCs with recording ISRCs

### DIFF
--- a/picard/metadata.py
+++ b/picard/metadata.py
@@ -288,6 +288,21 @@ def trackcount_score(actual, expected):
         return max(0.0, 1.0 - ratio * 2)
 
 
+def isrcs_score(file_isrcs: Iterable[str], track_isrcs: Iterable[str]) -> float:
+    file_isrcs = set(isrc.upper() for isrc in file_isrcs)
+    track_isrcs = set(isrc.upper() for isrc in track_isrcs)
+    # No file ISRCs, undefined match
+    if not file_isrcs:
+        return 0.5
+    # All file ISRCs are present in the track ISRCs — perfect match
+    elif file_isrcs.issubset(track_isrcs):
+        return 1.0
+    # Some file ISRCs are present in the track ISRCs — partial match
+    elif file_isrcs.intersection(track_isrcs):
+        return 0.8
+    return 0.0
+
+
 class Metadata(MutableMapping[str, str | list[str] | None]):
     """List of metadata items with dict-like access."""
 
@@ -541,12 +556,12 @@ class Metadata(MutableMapping[str, str | list[str] | None]):
         with self._lock.lock_for_read():
             # Tier 1: ISRC — recording-level identifier
             if 'isrc' in id_w:
-                file_isrc = self.get('isrc', '')
-                if file_isrc:
+                file_isrcs = self.getall('isrc')
+                if file_isrcs:
                     recording = track.get('recording', track)
                     track_isrcs = recording.get('isrcs', [])
                     if track_isrcs:
-                        score = 1.0 if file_isrc in track_isrcs else 0.0
+                        score = isrcs_score(file_isrcs, track_isrcs)
                         track_parts.identifiers.append((score, id_w['isrc']))
 
             # Track-level similarity signals

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -46,6 +46,7 @@ from picard.metadata import (
     MultiMetadataProxy,
     ReleaseMatchParts,
     _get_weighted_release_parts,
+    isrcs_score,
     trackcount_score,
     weights_from_preferred_countries,
     weights_from_preferred_formats,
@@ -687,6 +688,16 @@ class CommonTests:
             self.assertEqual(1.0, trackcount_score(5, 5))
             self.assertAlmostEqual(0.4, trackcount_score(6, 5))  # 1 - (1/5)*3
             self.assertAlmostEqual(0.6, trackcount_score(4, 5))  # 1 - (1/5)*2
+
+        def test_isrcs_score(self):
+            self.assertEqual(1.0, isrcs_score(['ISRC1', 'ISRC2'], ['ISRC1', 'ISRC2']))
+            self.assertEqual(1.0, isrcs_score(['ISRC1'], ['ISRC1']))
+            self.assertEqual(1.0, isrcs_score(['ISRC1'], ['ISRC1', 'ISRC2']))
+            self.assertEqual(0.8, isrcs_score(['ISRC1', 'ISRC2'], ['ISRC2', 'ISRC3']))
+            self.assertEqual(0.0, isrcs_score(['ISRC1'], ['ISRC2', 'ISRC3']))
+            self.assertEqual(0.0, isrcs_score(['ISRC1'], []))
+            self.assertEqual(0.5, isrcs_score([], []))
+            self.assertEqual(0.5, isrcs_score([], ['ISRC1', 'ISRC2']))
 
         def test_combine_tiers_no_identifiers(self):
             """Without identifiers, similarity drives the score."""


### PR DESCRIPTION
Check, whether the file's ISRCs are a subset or at least an intersection with the recording's ISRCs.
