### PR TITLE
Improve static typing

### DIFF
--- a/picard/audit.py
+++ b/picard/audit.py
@@ -20,7 +20,7 @@
 
 
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Iterator
 import sys
 import threading
 import time
@@ -55,7 +55,7 @@ def setup_audit(prefixes_string: str) -> None:
     sys.addaudithook(audit)
 
 
-def list_from_prefixes_string(prefixes_string: str) -> Generator[tuple[str, ...], None, None]:
+def list_from_prefixes_string(prefixes_string: str) -> Iterator[tuple[str, ...]]:
     """Generate a sorted list of prefixes tuples
     A prefixes string is a comma-separated list of dot-separated keys
     "a,b.c,d.e.f,,g" would result in following sorted list:
@@ -75,7 +75,7 @@ def make_prefixes_dict(prefixes_string: str) -> dict[int, list[tuple[str, ...]]]
 def prefixes_candidates_for_length(
     length: int,
     prefixes_dict: dict[int, list[tuple[str, ...]]],
-) -> Generator[tuple[str, ...], None, None]:
+) -> Iterator[tuple[str, ...]]:
     """Generate prefixes that may match this length"""
     for prefix_len, prefixes in prefixes_dict.items():
         if length >= prefix_len:

--- a/picard/collection.py
+++ b/picard/collection.py
@@ -28,6 +28,8 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any
 
+from PyQt6.QtNetwork import QNetworkReply
+
 from picard import (
     log,
     tagger_instance,
@@ -37,6 +39,7 @@ from picard.i18n import (
     N_,
     ngettext,
 )
+from picard.webservice import ReplyHandler
 from picard.webservice.api_helpers import MBAPIHelper
 
 
@@ -66,7 +69,7 @@ class Collection:
 
     def _modify(
         self,
-        api_method: Callable,
+        api_method: Callable[[str, list[str], ReplyHandler], None],
         success_handler: Callable[[set[str], Callable], None],
         releases: set[str],
         callback: Callable,
@@ -91,8 +94,8 @@ class Collection:
         releases: set[str],
         callback: Callable,
         document: Any,
-        reply: Any,
-        error: Any,
+        reply: QNetworkReply,
+        error: QNetworkReply.NetworkError | Exception | None,
     ) -> None:
         self.pending_releases -= releases
         if not error:
@@ -100,7 +103,7 @@ class Collection:
         else:
             self._error(reply)
 
-    def _error(self, reply: Any) -> None:
+    def _error(self, reply: QNetworkReply) -> None:
         self.tagger.window.set_statusbar_message(
             N_("Error while modifying collections: %(error)s"),
             {'error': reply.errorString()},

--- a/picard/coverart/processing/__init__.py
+++ b/picard/coverart/processing/__init__.py
@@ -47,6 +47,7 @@ from picard.extension_points.cover_art_processors import (
     ProcessingImage,
     get_cover_art_processors,
 )
+from picard.metadata import Metadata
 from picard.util import thread
 from picard.util.imageinfo import (
     IdentificationError,
@@ -54,21 +55,21 @@ from picard.util.imageinfo import (
 )
 
 
-def run_image_filters(data, image_info, album, coverartimage):
+def run_image_filters(data: bytes, image_info: ImageInfo, album: Album, coverartimage: CoverArtImage) -> bool:
     for f in ext_point_cover_art_filters:
         if not f(data, image_info, album, coverartimage):
             return False
     return True
 
 
-def run_image_metadata_filters(metadata):
+def run_image_metadata_filters(metadata: Metadata) -> bool:
     for f in ext_point_cover_art_metadata_filters:
         if not f(metadata):
             return False
     return True
 
 
-def handle_processing_exceptions(func):
+def handle_processing_exceptions(func: Callable) -> Callable:
     def wrapper(self, *args, **kwargs):
         try:
             func(self, *args, **kwargs)
@@ -95,7 +96,7 @@ class CoverArtImageProcessing:
         save_images_to_files: bool,
         image: ProcessingImage,
         target: ImageProcessor.Target,
-    ):
+    ) -> None:
         try:
             queue = self.queues[target]
             if queue:
@@ -123,7 +124,7 @@ class CoverArtImageProcessing:
         coverartimage: CoverArtImage,
         initial_data: bytes,
         image_info: ImageInfo,
-    ):
+    ) -> None:
         config = get_config()
         try:
             start_time = time.time()
@@ -191,7 +192,7 @@ class CoverArtImageProcessing:
         initial_data: bytes,
         image_info: ImageInfo,
         callback: Callable[[CoverArtImage, Exception | None], None],
-    ):
+    ) -> None:
         if coverartimage.can_be_processed:
             run_processors = partial(self._run_image_processors, coverartimage, initial_data, image_info)
 
@@ -203,7 +204,7 @@ class CoverArtImageProcessing:
             coverartimage.set_data(initial_data)
             callback(coverartimage, None)
 
-    def wait_for_processing(self):
+    def wait_for_processing(self) -> bool:
         self.task_counter.wait_for_tasks()
         has_io_error = False
         while not self.errors.empty():

--- a/picard/coverart/setters/handlers.py
+++ b/picard/coverart/setters/handlers.py
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from collections.abc import Generator
+from collections.abc import Iterator
 from contextlib import ExitStack
 from functools import singledispatch
 
@@ -163,7 +163,7 @@ def _handle_file(file: File, setter) -> bool:
     return True
 
 
-def _iter_file_parents(file: File) -> Generator[MetadataItem, None, None]:
+def _iter_file_parents(file: File) -> Iterator[MetadataItem]:
     """
     Iterate over the parent objects of a file.
 

--- a/picard/disc/dbpoweramplog.py
+++ b/picard/disc/dbpoweramplog.py
@@ -21,7 +21,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from collections.abc import Iterator
+from collections.abc import (
+    Iterable,
+    Iterator,
+)
 import re
 
 from picard.disc.utils import (
@@ -35,7 +38,7 @@ from picard.util import detect_file_encoding
 RE_TOC_ENTRY = re.compile(r"^Track (?P<num>\d+):\s+Ripped LBA (?P<start_sector>\d+) to (?P<end_sector>\d+)")
 
 
-def filter_toc_entries(lines: Iterator[str]) -> Iterator[TocEntry]:
+def filter_toc_entries(lines: Iterable[str]) -> Iterator[TocEntry]:
     """
     Take iterator of lines, return iterator of toc entries
     """

--- a/picard/disc/eaclog.py
+++ b/picard/disc/eaclog.py
@@ -25,7 +25,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from collections.abc import Iterator
+from collections.abc import (
+    Iterable,
+    Iterator,
+)
 import re
 
 from picard.disc.utils import (
@@ -63,7 +66,7 @@ RE_TOC_TABLE_LINE = re.compile(
 )
 
 
-def filter_toc_entries(lines: Iterator[str]) -> Iterator[TocEntry]:
+def filter_toc_entries(lines: Iterable[str]) -> Iterator[TocEntry]:
     """
     Take iterator of lines, return iterator of toc entries
     """

--- a/picard/extension_points/cover_art_filters.py
+++ b/picard/extension_points/cover_art_filters.py
@@ -20,17 +20,31 @@
 
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
+from picard.album import Album
+from picard.coverart.image import CoverArtImage
+from picard.metadata import Metadata
 from picard.plugin import ExtensionPoint
+
+
+if TYPE_CHECKING:
+    from picard.plugin3.api import ImageInfo
 
 
 ext_point_cover_art_filters = ExtensionPoint(label='cover_art_filters')
 ext_point_cover_art_metadata_filters = ExtensionPoint(label='cover_art_metadata_filters')
 
 
-def register_cover_art_filter(cover_art_filter: Callable) -> None:
+def register_cover_art_filter(
+    cover_art_filter: Callable[[bytes, 'ImageInfo', Album | None, CoverArtImage], bool],
+) -> None:
     ext_point_cover_art_filters.register(cover_art_filter.__module__, cover_art_filter)
 
 
-def register_cover_art_metadata_filter(cover_art_metadata_filter: Callable) -> None:
+def register_cover_art_metadata_filter(
+    cover_art_metadata_filter: Callable[[Metadata], bool],
+) -> None:
+    m = Metadata()
+    cover_art_metadata_filter(m)
     ext_point_cover_art_metadata_filters.register(cover_art_metadata_filter.__module__, cover_art_metadata_filter)

--- a/picard/extension_points/cover_art_processors.py
+++ b/picard/extension_points/cover_art_processors.py
@@ -178,7 +178,7 @@ class ImageProcessor:
         pass
 
 
-def get_cover_art_processors():
+def get_cover_art_processors() -> dict[ImageProcessor.Target, list[ImageProcessor]]:
     queues = defaultdict(list)
     for processor in ext_point_cover_art_processors:
         target = processor.target()

--- a/picard/extension_points/cover_art_providers.py
+++ b/picard/extension_points/cover_art_providers.py
@@ -24,6 +24,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from picard.coverart.providers.provider import CoverArtProvider
 from picard.extension_points.options_pages import register_options_page
 from picard.plugin import ExtensionPoint
 
@@ -31,11 +32,11 @@ from picard.plugin import ExtensionPoint
 ext_point_cover_art_providers = ExtensionPoint(label='cover_art_providers')
 
 
-def register_cover_art_provider(provider: type) -> None:
+def register_cover_art_provider(provider: type[CoverArtProvider]) -> None:
     ext_point_cover_art_providers.register(provider.__module__, provider)
-    if getattr(provider, 'OPTIONS', None):
-        if not hasattr(provider.OPTIONS, 'NAME'):
-            provider.OPTIONS.NAME = provider.name.lower().replace(' ', '_')
-        if not hasattr(provider.OPTIONS, 'TITLE'):
-            provider.OPTIONS.TITLE = provider.display_title()
-        register_options_page(provider.OPTIONS)
+    if options_page := getattr(provider, 'OPTIONS', None):
+        if not hasattr(options_page, 'NAME'):
+            options_page.NAME = provider.name.lower().replace(' ', '_')
+        if not hasattr(options_page, 'TITLE'):
+            options_page.TITLE = provider.display_title()
+        register_options_page(options_page)

--- a/picard/extension_points/event_hooks.py
+++ b/picard/extension_points/event_hooks.py
@@ -52,17 +52,22 @@
 
 from collections.abc import Callable
 
-from picard.album import album_post_removal_processors
+from picard.album import (
+    Album,
+    album_post_removal_processors,
+)
 from picard.file import (
+    File,
     file_post_addition_to_track_processors,
     file_post_load_processors,
     file_post_removal_to_track_processors,
     file_post_save_processors,
     file_pre_save_processors,
 )
+from picard.track import Track
 
 
-def register_album_post_removal_processor(function: Callable, priority: int = 0) -> None:
+def register_album_post_removal_processor(function: Callable[[Album], None], priority: int = 0) -> None:
     """Registers an album-removed processor.
     Args:
         function: function to call after album removal, it will be passed the album object
@@ -73,7 +78,7 @@ def register_album_post_removal_processor(function: Callable, priority: int = 0)
     album_post_removal_processors.register(function.__module__, function, priority)
 
 
-def register_file_post_load_processor(function: Callable, priority: int = 0) -> None:
+def register_file_post_load_processor(function: Callable[[File], None], priority: int = 0) -> None:
     """Registers a file-loaded processor.
 
     Args:
@@ -85,7 +90,7 @@ def register_file_post_load_processor(function: Callable, priority: int = 0) -> 
     file_post_load_processors.register(function.__module__, function, priority)
 
 
-def register_file_post_addition_to_track_processor(function: Callable, priority: int = 0) -> None:
+def register_file_post_addition_to_track_processor(function: Callable[[Track, File], None], priority: int = 0) -> None:
     """Registers a file-added-to-track processor.
 
     Args:
@@ -97,7 +102,7 @@ def register_file_post_addition_to_track_processor(function: Callable, priority:
     file_post_addition_to_track_processors.register(function.__module__, function, priority)
 
 
-def register_file_post_removal_from_track_processor(function: Callable, priority: int = 0) -> None:
+def register_file_post_removal_from_track_processor(function: Callable[[Track, File], None], priority: int = 0) -> None:
     """Registers a file-removed-from-track processor.
 
     Args:
@@ -109,7 +114,7 @@ def register_file_post_removal_from_track_processor(function: Callable, priority
     file_post_removal_to_track_processors.register(function.__module__, function, priority)
 
 
-def register_file_pre_save_processor(function: Callable, priority: int = 0) -> None:
+def register_file_pre_save_processor(function: Callable[[File], None], priority: int = 0) -> None:
     """Registers file pre-save processor.
 
     Called before saving tags and any rename / move operations.
@@ -125,7 +130,7 @@ def register_file_pre_save_processor(function: Callable, priority: int = 0) -> N
     file_pre_save_processors.register(function.__module__, function, priority)
 
 
-def register_file_post_save_processor(function: Callable, priority: int = 0) -> None:
+def register_file_post_save_processor(function: Callable[[File], None], priority: int = 0) -> None:
     """Registers file saved processor.
 
     Args:

--- a/picard/extension_points/metadata.py
+++ b/picard/extension_points/metadata.py
@@ -38,17 +38,22 @@
 
 from collections.abc import Callable
 
+from picard.album import Album
 from picard.metadata import (
+    Metadata,
     album_metadata_processors,
     track_metadata_processors,
 )
+from picard.track import Track
 
 
-def register_album_metadata_processor(function: Callable, priority: int = 0) -> None:
+def register_album_metadata_processor(function: Callable[[Album, Metadata, dict], None], priority: int = 0) -> None:
     """Registers new album-level metadata processor."""
     album_metadata_processors.register(function.__module__, function, priority)
 
 
-def register_track_metadata_processor(function: Callable, priority: int = 0) -> None:
+def register_track_metadata_processor(
+    function: Callable[[Track, Metadata, dict, dict | None], None], priority: int = 0
+) -> None:
     """Registers new track-level metadata processor."""
     track_metadata_processors.register(function.__module__, function, priority)

--- a/picard/extension_points/options_pages.py
+++ b/picard/extension_points/options_pages.py
@@ -25,11 +25,13 @@
 
 from picard.plugin import ExtensionPoint
 
+from picard.ui.options import OptionsPage
+
 
 ext_point_options_pages = ExtensionPoint(label='options_pages')
 
 
-def register_options_page(page_class: type) -> None:
+def register_options_page(page_class: type[OptionsPage]) -> None:
     ext_point_options_pages.register(page_class.__module__, page_class)
     for opt_name, opt_highlights in page_class.OPTIONS:
         page_class.register_setting(opt_name, opt_highlights)

--- a/picard/extension_points/plugin_tools_menu.py
+++ b/picard/extension_points/plugin_tools_menu.py
@@ -23,6 +23,7 @@ from PyQt6.QtCore import (
     pyqtSignal,
 )
 
+from picard.extension_points.item_actions import BaseAction
 from picard.plugin import ExtensionPoint
 
 
@@ -34,6 +35,6 @@ signaler = Signaler()
 ext_point_plugin_tools_items = ExtensionPoint(label='plugin_tools_items')
 
 
-def register_tools_menu_action(action: type) -> None:
+def register_tools_menu_action(action: type[BaseAction]) -> None:
     ext_point_plugin_tools_items.register(action.__module__, action)
     signaler.plugin_tools_updated.emit()

--- a/picard/extension_points/script_functions.py
+++ b/picard/extension_points/script_functions.py
@@ -149,7 +149,7 @@ def register_script_function(
         documentation = function.__doc__
 
     if name is None:
-        name = function.__name__
+        name = getattr(function, "__name__", str(function))
 
     if not signature:
         signature = generate_function_signature(name, argspec)

--- a/picard/formats/registry.py
+++ b/picard/formats/registry.py
@@ -18,7 +18,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Iterator
 from pathlib import Path
 
 from PyQt6.QtCore import (
@@ -56,7 +56,7 @@ class FormatRegistry(QObject):
 
         self.formats_changed.emit()
 
-    def __iter__(self) -> Generator[File, None, None]:
+    def __iter__(self) -> Iterator[File]:
         yield from self._ext_point_formats
 
     def supported_formats(self) -> list[tuple[list[str], str]]:

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -30,8 +30,8 @@
 from collections import defaultdict
 from collections.abc import (
     Callable,
-    Generator,
     Iterable,
+    Iterator,
 )
 from dataclasses import dataclass
 from typing import (
@@ -684,7 +684,7 @@ def artist_credit_to_metadata(node: list[Node], m: 'Metadata', release: bool = F
         m['~artists_countries'] = credits.countries
 
 
-def _release_event_iter(node: Node) -> Generator[Node, None, None]:
+def _release_event_iter(node: Node) -> Iterator[Node]:
     if 'release-events' in node:
         yield from node['release-events']
 
@@ -753,7 +753,7 @@ def media_formats_from_node(node: list[Node]) -> str:
     return " + ".join(formats)
 
 
-def _node_skip_empty_iter(node: Node) -> Generator[tuple[str, Any], None, None]:
+def _node_skip_empty_iter(node: Node) -> Iterator[tuple[str, Any]]:
     for key, value in node.items():
         if value or value == 0:
             yield key, value

--- a/picard/plugin.py
+++ b/picard/plugin.py
@@ -34,7 +34,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from collections import namedtuple
-from collections.abc import Generator
+from collections.abc import (
+    Callable,
+    Iterator,
+)
 from functools import partial
 
 from picard.config import (
@@ -75,12 +78,12 @@ class PluginFunctions:
         self.processor_type = label.split('_')[0] if label else ''
         Option.add_if_missing('setting', 'plugins3_exec_order', dict())
 
-    def make_exec_order_key(self, function: object) -> str:
+    def make_exec_order_key(self, function: Callable) -> str:
         """Make the plugin key based on the module name"""
-        key = f"{function.__module__}:{self.processor_type}:{function.__name__}"
+        key = f"{function.__module__}:{self.processor_type}:{getattr(function, '__name__', str(function))}"
         return key
 
-    def get_priority(self, function: object) -> int:
+    def get_priority(self, function: Callable) -> int:
         key = self.make_exec_order_key(function)
         if key in self.config_priorities:
             return self.config_priorities[key]
@@ -88,7 +91,7 @@ class PluginFunctions:
             return self.priorities[key]
         return 0  # Default priority
 
-    def register(self, module: str, item: object, priority: int = 0) -> None:
+    def register(self, module: str, item: Callable, priority: int = 0) -> None:
         key = self.make_exec_order_key(item)
         self.priorities[key] = priority
         self.functions.register(module, item)
@@ -97,9 +100,7 @@ class PluginFunctions:
             config_priorities = config.setting['plugins3_exec_order']
             config_priorities[key] = config_priorities[key] if key in config_priorities else priority
 
-    def get_plugin_function_information(
-        self, order_dict: dict | None = None
-    ) -> Generator[PluginInformation, None, None]:
+    def get_plugin_function_information(self, order_dict: dict | None = None) -> Iterator[PluginInformation]:
         """Returns registered functions for manually setting execution order"""
         if order_dict is None:
             config = get_config()
@@ -134,7 +135,7 @@ class PluginFunctions:
                 priority=self.get_priority(function),
             )
 
-    def _get_functions(self) -> Generator[object, None, None]:
+    def _get_functions(self) -> Iterator[Callable]:
         """Returns registered functions by order of priority (highest first) and registration"""
         config = get_config()
         self.config_priorities = dict(config.setting['plugins3_exec_order'])

--- a/picard/plugin3/api_impl.py
+++ b/picard/plugin3/api_impl.py
@@ -711,7 +711,7 @@ class PluginApi:
         update_wrapper(wrapped, filter)
         return register_cover_art_filter(wrapped)
 
-    def register_cover_art_metadata_filter(self, filter: Callable[['PluginApi', dict], bool]) -> None:
+    def register_cover_art_metadata_filter(self, filter: Callable[['PluginApi', Metadata], bool]) -> None:
         wrapped = partial(filter, self)
         update_wrapper(wrapped, filter)
         return register_cover_art_metadata_filter(wrapped)

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -28,6 +28,11 @@ from collections import (
     namedtuple,
 )
 from collections.abc import Generator
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from picard.ui.options import OptionsPage
 
 
 SettingDesc = namedtuple('SettingDesc', ('name', 'highlights'))
@@ -81,7 +86,7 @@ def profile_groups_keys() -> Generator[str, None, None]:
     yield from _settings_groups.keys()
 
 
-def profile_groups_group_from_page(page: object) -> dict | None:
+def profile_groups_group_from_page(page: 'OptionsPage') -> dict | None:
     try:
         return _settings_groups[page.NAME]
     except (AttributeError, KeyError):

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -27,7 +27,7 @@ from collections import (
     defaultdict,
     namedtuple,
 )
-from collections.abc import Generator
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 
@@ -71,13 +71,13 @@ def profile_groups_all_settings() -> set[str]:
     return _known_settings
 
 
-def profile_groups_settings(group: str) -> Generator[SettingDesc, None, None]:
+def profile_groups_settings(group: str) -> Iterator[SettingDesc]:
     if group in _settings_groups:
         if 'settings' in _settings_groups[group]:
             yield from _settings_groups[group]['settings']
 
 
-def profile_groups_keys() -> Generator[str, None, None]:
+def profile_groups_keys() -> Iterator[str]:
     """Iterable of all setting groups keys.
 
     Yields:
@@ -93,7 +93,7 @@ def profile_groups_group_from_page(page: 'OptionsPage') -> dict | None:
         return None
 
 
-def profile_groups_values() -> Generator[dict, None, None]:
+def profile_groups_values() -> Iterator[dict]:
     """Returns values sorted by (groups_order, group name)"""
     # Yield top level groups first to ensure that they are created in the
     # QTreeWidget before adding their children.

--- a/picard/releasegroup.py
+++ b/picard/releasegroup.py
@@ -26,9 +26,12 @@
 
 
 from collections import defaultdict
+from collections.abc import Callable
 from functools import partial
 from itertools import combinations
 import traceback
+
+from PyQt6.QtNetwork import QNetworkReply
 
 from picard import log
 from picard.i18n import (
@@ -113,7 +116,7 @@ class ReleaseGroup(MetadataItem):
         self.refcount = 0
         self.versions_count: int | None = None
 
-    def load_versions(self, callback: object) -> None:
+    def load_versions(self, callback: Callable) -> None:
         kwargs = {'release-group': self.id, 'limit': 100}
         self.tagger.mb_api.browse_releases(partial(self._request_finished, callback), **kwargs)
 
@@ -164,7 +167,13 @@ class ReleaseGroup(MetadataItem):
                 }
                 self.versions.append(version)
 
-    def _request_finished(self, callback: object, document: dict, http: object, error: object) -> None:
+    def _request_finished(
+        self,
+        callback: Callable,
+        document: dict,
+        http: QNetworkReply,
+        error: QNetworkReply.NetworkError | Exception | None,
+    ) -> None:
         try:
             if error:
                 log.error("%r", http.errorString())
@@ -172,7 +181,6 @@ class ReleaseGroup(MetadataItem):
                 try:
                     self._parse_versions(document)
                 except BaseException:
-                    error = True
                     log.error(traceback.format_exc())
         finally:
             self.loaded = True

--- a/picard/ui/dialogs/cover_types_selector.py
+++ b/picard/ui/dialogs/cover_types_selector.py
@@ -18,8 +18,8 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 from collections.abc import (
-    Generator,
     Iterable,
+    Iterator,
 )
 
 from PyQt6 import (
@@ -82,7 +82,7 @@ class CoverTypesSelectorDialog(PicardDialog):
     def reset_to_defaults(self):
         self._update_checked_items(DEFAULT_CA_NEVER_REPLACE_TYPES)
 
-    def selected_types(self) -> Generator[str, None, None]:
+    def selected_types(self) -> Iterator[str]:
         for i in range(self._types_list.count()):
             item = self._types_list.item(i)
             if item and item.checkState() == QtCore.Qt.CheckState.Checked:

--- a/picard/webservice/api_helpers/musicbrainz.py
+++ b/picard/webservice/api_helpers/musicbrainz.py
@@ -21,8 +21,8 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 from collections.abc import (
-    Generator,
     Iterable,
+    Iterator,
     Sequence,
 )
 import re
@@ -256,9 +256,7 @@ class MBAPIHelper(APIHelper):
         return self.get_collection(None, handler)
 
     @staticmethod
-    def _collection_request(
-        collection_id: str, releases: Sequence[str], batchsize: int = 400
-    ) -> Generator[str, None, None]:
+    def _collection_request(collection_id: str, releases: Sequence[str], batchsize: int = 400) -> Iterator[str]:
         for i in range(0, len(releases), batchsize):
             ids = ';'.join(releases[i : i + batchsize])
             yield f"/collection/{collection_id}/releases/{ids}"


### PR DESCRIPTION
Some improvements on top of your PR:

- Be more specific with type hints for Callables and type
- Prefer `Iterator` return type over `Generator`. In the majority of cases the `Generator` specifics are not used and treating the function being a Generator as an implementation details makes it more flexible to change the implementation later if needed.