### PR TITLE
Allow option highlights on option dialogs defining widgets in code

### DIFF
--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -440,10 +440,22 @@ class OptionsDialog(PicardDialog, SingletonDialog):
                         try:
                             obj = getattr(page.ui, objname)
                         except AttributeError:
+                            try:
+                                obj = getattr(page, objname)
+                            except AttributeError:
+                                log.warning(
+                                    "Option '%s' references widget '%s' not found on page '%s'",
+                                    opt.name,
+                                    objname,
+                                    page.NAME,
+                                )
+                                continue
+                        if not isinstance(obj, QtWidgets.QWidget):
                             log.warning(
-                                "Option '%s' references widget '%s' not found on page '%s'",
+                                "Option '%s' references widget '%s', expected QWidget, found '%s' on page '%s'",
                                 opt.name,
                                 objname,
+                                obj.__class__.__name__,
                                 page.NAME,
                             )
                             continue


### PR DESCRIPTION
The option widget highlighting code relied on the option page having a `.ui` attribute, which is the mechanism we use for loading the UI from a QtDesigner file.

This PR adds the ability to highlight widgets that get directly defined in code on the OptionsPage itself. E.g. for plugin code like this:

```python
class FooOptions(OptionsPage):

    OPTIONS = {
        "foo": {"widgets": ["foo_input"]}
    }

    def __init__(self, parent=None):
        super().__init__(parent)
        self.vboxlayout = QtWidgets.QVBoxLayout(self)
        self.vboxlayout.setContentsMargins(9, 9, 9, 9)
        self.vboxlayout.setSpacing(6)

        self.foo_input = QtWidgets.QLineEdit(self)
        self.foo_input.setObjectName("foo_input")
        self.vboxlayout.addWidget(self.foo_input)


    def load(self):
        self.foo_input.setText(self.api.plugin_config["foo"])

    def save(self):
        self.api.plugin_config["foo"] = self.foo_input.text()
```

Especially plugin authors might choose not to use QtDesigner, in particular if they have otherwise not all the Qt toolbox installed.

Also this PR adds a check to ensure the found object is indeed an instance of QWidget, as otherwise there would be an exception potentially crashing Picard later on when trying to set the stylesheet. If the found obj is not a QWidget a warning is logged. This avoids errors during development (again especially for plugin authors).

Note: There are still a few things to consider: The attribute name and the Qt object name of the widget need to match. Hence a widget must always be defined something like this:

```python
self.foo_input = QtWidgets.QLineEdit(self)
self.foo_input.setObjectName("foo_input")
```