### PR TITLE
Unified config upgrades

### DIFF
--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -213,7 +213,7 @@ def upgrade_option_value(
     Polymorphic: works on both plain dicts (profile overrides, imported
     settings) and ConfigSection objects (base config at startup).
 
-    The transform function receives the current value and must return the
+    The transform function receives the current raw value and must return the
     new value. Settings with None value (tracked but not overridden in
     profile dicts) are left unchanged.
 

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -239,41 +239,36 @@ def get_option_value(
     settings: Settings,
     name: str,
     option_type: type[Option],
-    default: ConfigValueType | None,
+    default: ConfigValueType,
 ) -> Any:
     """Read an option value from settings.
 
     Polymorphic: works on both plain dicts and ConfigSection objects.
 
-    For plain dicts, the value is already a Python object (bool, int, str, etc.)
-    and is returned directly.
-
-    For ConfigSection, the option_type is needed to deserialize the raw value
-    from QSettings (via a temporarily registered Option).
+    The option_type is required to apply necessary type transformations.
 
     Args:
         settings: A plain dict or a ConfigSection instance.
         name: The option key name to read.
-        option_type: Option class (e.g., BoolOption). Required for ConfigSection,
-                     ignored for plain dicts.
-        default: Default value if the key is missing. Required for ConfigSection,
-                 ignored for plain dicts (returns None if missing and no default).
+        option_type: Option class (e.g., BoolOption).
+        default: Default value if the key is missing. Must not be None.
 
     Returns:
         The option value (deserialized), or default if the key is not present.
     """
+    assert option_type is not None
+    assert default is not None
+
     if isinstance(settings, dict):
         value = settings.get(name, default)
         if value is None:
             return None
-        assert default is not None
         with temp_option(option_type, 'upgrade', name, default) as opt:
             value = opt.convert(value)
         return value
     else:
         if name not in settings:
             return default
-        assert default is not None
         with temp_option(option_type, settings.section_name, name, default) as opt:
             return settings.value(opt, default)
 

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -235,13 +235,13 @@ def upgrade_option_value(
                     settings[name] = transform(value)
 
 
-def get_option(
+def get_option_value(
     settings: Settings,
     name: str,
     option_type: type[Option],
     default: ConfigValueType | None,
 ) -> Any:
-    """Read an option value from settings without removing it.
+    """Read an option value from settings.
 
     Polymorphic: works on both plain dicts and ConfigSection objects.
 

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -238,8 +238,8 @@ def upgrade_option_value(
 def get_option(
     settings: Settings,
     name: str,
-    option_type: type[Option] | None = None,
-    default: ConfigValueType | None = None,
+    option_type: type[Option],
+    default: ConfigValueType | None,
 ) -> Any:
     """Read an option value from settings without removing it.
 
@@ -263,12 +263,17 @@ def get_option(
         The option value (deserialized), or default if the key is not present.
     """
     if isinstance(settings, dict):
-        return settings.get(name, default)
-    else:
-        assert option_type is not None
+        value = settings.get(name, default)
+        if value is None:
+            return None
         assert default is not None
+        with temp_option(option_type, 'upgrade', name, default) as opt:
+            value = opt.convert(value)
+        return value
+    else:
         if name not in settings:
             return default
+        assert default is not None
         with temp_option(option_type, settings.section_name, name, default) as opt:
             return settings.value(opt, default)
 

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -33,6 +33,7 @@ from itertools import groupby
 from typing import (
     Any,
     NamedTuple,
+    TypeAlias,
 )
 
 from picard import log
@@ -53,6 +54,8 @@ from picard.version import (
 # (base config at startup).
 Settings = dict | SettingConfigSection
 
+SettingsUpgradeFunc: TypeAlias = Callable[[Settings], None]
+ConfigUpgradeFunc: TypeAlias = Callable[[Config], None]
 
 # TO ADD AN UPGRADE HOOK:
 # See config_upgrade_hooks.py
@@ -90,7 +93,7 @@ class _UpgradeEntry(NamedTuple):
 _UPGRADES_REGISTRY: list[_UpgradeEntry] = []
 
 
-def upgrade_settings(version_str: str):
+def upgrade_settings(version_str: str) -> Callable[[SettingsUpgradeFunc], None]:
     """Decorator to register a settings upgrade function.
 
     The decorated function receives a single argument: either a plain dict
@@ -117,7 +120,7 @@ def upgrade_settings(version_str: str):
     return decorator
 
 
-def upgrade_config(version_str: str):
+def upgrade_config(version_str: str) -> Callable[[ConfigUpgradeFunc], None]:
     """Decorator to register a config upgrade function (non-settings operations).
 
     The decorated function receives the full Config object. Use this for

--- a/picard/config_upgrade_hooks.py
+++ b/picard/config_upgrade_hooks.py
@@ -48,7 +48,7 @@ from picard.config import (
     TextOption,
 )
 from picard.config_upgrade import (
-    get_option,
+    get_option_value,
     remove_option,
     rename_option,
     temp_option,
@@ -367,7 +367,7 @@ def convert_caa_image_size(config):
 def upgrade_genre_options(settings):
     """Upgrade genre related options"""
     if 'folksonomy_tags' in settings:
-        value = get_option(settings, 'folksonomy_tags', BoolOption, False)
+        value = get_option_value(settings, 'folksonomy_tags', BoolOption, False)
         if value:
             write_option(settings, 'use_genres', True)
     rename_option(settings, 'max_tags', 'max_genres', IntOption, 5)
@@ -663,7 +663,7 @@ def sanitize_replace_dir_separator(settings):
 def copy_standardize_instruments_to_vocals(settings):
     """New independent option "standardize_vocals" should use the value of the old shared option"""
     if 'standardize_instruments' in settings:
-        value = get_option(settings, 'standardize_instruments', BoolOption, False)
+        value = get_option_value(settings, 'standardize_instruments', BoolOption, False)
         write_option(settings, 'standardize_vocals', value)
 
 
@@ -779,7 +779,7 @@ def convert_standardize_artists(settings):
     """Convert "standardize_artists" to "standardize_artist_names"."""
     if 'standardize_artists' not in settings:
         return
-    value = get_option(settings, 'standardize_artists', BoolOption, False)
+    value = get_option_value(settings, 'standardize_artists', BoolOption, False)
     write_option(
         settings,
         'standardize_artist_names',

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -257,11 +257,6 @@ class TestGetOption(PicardTestCase):
         self.assertEqual(result, 'fallback')
         self.assertEqual(settings, {'other': 42})
 
-    def test_read_missing_key_no_default_returns_none(self):
-        settings = {'other': 42}
-        result = get_option_value(settings, 'old_key', option_type=IntOption, default=None)
-        self.assertIsNone(result)
-
     def test_read_bool_value(self):
         settings = {'flag': True}
         result = get_option_value(settings, 'flag', option_type=BoolOption, default=False)

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -21,7 +21,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from enum import Enum, IntEnum
+from enum import (
+    Enum,
+    IntEnum,
+)
 
 from test.picardtestcase import PicardTestCase
 
@@ -32,42 +35,47 @@ from picard.config import (
     Option,
     TextOption,
 )
+from picard.config_upgrade import (
+    _UPGRADES_REGISTRY,
+    _get_sorted_upgrades,
+    _UpgradeEntry,
+    _UpgradeType,
+    apply_settings_upgrades_for_import,
+    get_option,
+    remove_option,
+    rename_option,
+    upgrade_config,
+    upgrade_option_value,
+    upgrade_settings,
+    write_option,
+)
+from picard.version import Version
 
 
 class TestRenameOptionInSettingsPolymorphic(PicardTestCase):
     """Tests for the new polymorphic rename_option (dict path)."""
 
     def test_rename_existing_key(self):
-        from picard.config_upgrade import rename_option
-
         settings = {'old_name': 'value', 'other': 42}
         rename_option(settings, 'old_name', 'new_name')
         self.assertEqual({'new_name': 'value', 'other': 42}, settings)
 
     def test_rename_with_reverse(self):
-        from picard.config_upgrade import rename_option
-
         settings = {'old_name': True}
         rename_option(settings, 'old_name', 'new_name', reverse=True)
         self.assertEqual({'new_name': False}, settings)
 
     def test_rename_missing_key(self):
-        from picard.config_upgrade import rename_option
-
         settings = {'other': 'value'}
         rename_option(settings, 'old_name', 'new_name')
         self.assertEqual({'other': 'value'}, settings)
 
     def test_rename_none_value(self):
-        from picard.config_upgrade import rename_option
-
         settings = {'old_name': None}
         rename_option(settings, 'old_name', 'new_name')
         self.assertEqual({'new_name': None}, settings)
 
     def test_rename_none_value_reverse(self):
-        from picard.config_upgrade import rename_option
-
         settings = {'old_name': None}
         rename_option(settings, 'old_name', 'new_name', reverse=True)
         self.assertEqual({'new_name': None}, settings)
@@ -77,29 +85,21 @@ class TestUpgradeOptionValueInSettingsPolymorphic(PicardTestCase):
     """Tests for the new polymorphic upgrade_option_value (dict path)."""
 
     def test_transform_existing_key(self):
-        from picard.config_upgrade import upgrade_option_value
-
         settings = {'my_opt': 'HELLO', 'other': 42}
         upgrade_option_value(settings, 'my_opt', str.lower)
         self.assertEqual({'my_opt': 'hello', 'other': 42}, settings)
 
     def test_transform_missing_key(self):
-        from picard.config_upgrade import upgrade_option_value
-
         settings = {'other': 42}
         upgrade_option_value(settings, 'my_opt', str.lower)
         self.assertEqual({'other': 42}, settings)
 
     def test_transform_none_value_unchanged(self):
-        from picard.config_upgrade import upgrade_option_value
-
         settings = {'my_opt': None}
         upgrade_option_value(settings, 'my_opt', str.lower)
         self.assertEqual({'my_opt': None}, settings)
 
     def test_transform_list(self):
-        from picard.config_upgrade import upgrade_option_value
-
         settings = {'items': [('Whitelist', True), ('Other', False)]}
         upgrade_option_value(
             settings,
@@ -113,13 +113,6 @@ class TestUpgradeSettingsDecorator(PicardTestCase):
     """Tests for the @upgrade_settings decorator and registry."""
 
     def test_decorator_registers_function(self):
-        from picard.config_upgrade import (
-            _UPGRADES_REGISTRY,
-            _UpgradeType,
-            upgrade_settings,
-        )
-        from picard.version import Version
-
         original_len = len(_UPGRADES_REGISTRY)
 
         @upgrade_settings('99.0.0dev1')
@@ -137,11 +130,6 @@ class TestUpgradeSettingsDecorator(PicardTestCase):
         _UPGRADES_REGISTRY.pop()
 
     def test_multiple_decorators_same_version(self):
-        from picard.config_upgrade import (
-            _UPGRADES_REGISTRY,
-            upgrade_settings,
-        )
-
         original_len = len(_UPGRADES_REGISTRY)
 
         @upgrade_settings('99.0.0dev2')
@@ -163,13 +151,6 @@ class TestUpgradeConfigDecorator(PicardTestCase):
     """Tests for the @upgrade_config decorator and registry."""
 
     def test_decorator_registers_function(self):
-        from picard.config_upgrade import (
-            _UPGRADES_REGISTRY,
-            _UpgradeType,
-            upgrade_config,
-        )
-        from picard.version import Version
-
         original_len = len(_UPGRADES_REGISTRY)
 
         @upgrade_config('99.0.0dev1')
@@ -191,8 +172,6 @@ class TestApplySettingsUpgradesForImport(PicardTestCase):
     """Tests for apply_settings_upgrades_for_import."""
 
     def test_applies_upgrades_after_version(self):
-        from picard.config_upgrade import apply_settings_upgrades_for_import
-
         # toolbar_multiselect was renamed at 3.0.0dev3
         settings = {'toolbar_multiselect': True}
         descriptions = apply_settings_upgrades_for_import(settings, '3.0.0dev2')
@@ -201,8 +180,6 @@ class TestApplySettingsUpgradesForImport(PicardTestCase):
         self.assertTrue(len(descriptions) > 0)
 
     def test_skips_upgrades_at_or_before_version(self):
-        from picard.config_upgrade import apply_settings_upgrades_for_import
-
         # If from_version >= the upgrade version, it should not apply
         settings = {'toolbar_multiselect': True}
         apply_settings_upgrades_for_import(settings, '3.0.0dev3')
@@ -211,8 +188,6 @@ class TestApplySettingsUpgradesForImport(PicardTestCase):
         self.assertNotIn('allow_multi_dirs_selection', settings)
 
     def test_invalid_version_returns_empty(self):
-        from picard.config_upgrade import apply_settings_upgrades_for_import
-
         settings = {'toolbar_multiselect': True}
         descriptions = apply_settings_upgrades_for_import(settings, 'not_a_version')
         self.assertEqual(descriptions, [])
@@ -220,8 +195,6 @@ class TestApplySettingsUpgradesForImport(PicardTestCase):
         self.assertIn('toolbar_multiselect', settings)
 
     def test_no_matching_keys_is_noop(self):
-        from picard.config_upgrade import apply_settings_upgrades_for_import
-
         settings = {'some_other_option': 'value'}
         apply_settings_upgrades_for_import(settings, '3.0.0dev2')
         self.assertEqual(settings, {'some_other_option': 'value'})
@@ -231,13 +204,6 @@ class TestGetSortedUpgrades(PicardTestCase):
     """Tests for _get_sorted_upgrades."""
 
     def test_sorts_by_version(self):
-        from picard.config_upgrade import (
-            _get_sorted_upgrades,
-            _UpgradeEntry,
-            _UpgradeType,
-        )
-        from picard.version import Version
-
         v1 = Version(3, 0, 0, 'dev', 3)
         v2 = Version(2, 0, 0, 'final', 0)
         v3 = Version(3, 0, 0, 'dev', 1)
@@ -259,13 +225,6 @@ class TestGetSortedUpgrades(PicardTestCase):
         self.assertEqual(result[2], _UpgradeEntry(v1, S, f1))
 
     def test_preserves_order_within_same_version(self):
-        from picard.config_upgrade import (
-            _get_sorted_upgrades,
-            _UpgradeEntry,
-            _UpgradeType,
-        )
-        from picard.version import Version
-
         v = Version(3, 0, 0, 'dev', 3)
         S = _UpgradeType.SETTINGS
         C = _UpgradeType.CONFIG
@@ -286,8 +245,6 @@ class TestGetOption(PicardTestCase):
     """Tests for the polymorphic get_option (dict path)."""
 
     def test_read_existing_key(self):
-        from picard.config_upgrade import get_option
-
         settings = {'old_key': 'value', 'other': 42}
         result = get_option(settings, 'old_key', option_type=TextOption, default='')
         self.assertEqual(result, 'value')
@@ -295,45 +252,33 @@ class TestGetOption(PicardTestCase):
         self.assertIn('old_key', settings)
 
     def test_read_missing_key_returns_default(self):
-        from picard.config_upgrade import get_option
-
         settings = {'other': 42}
         result = get_option(settings, 'old_key', option_type=TextOption, default='fallback')
         self.assertEqual(result, 'fallback')
         self.assertEqual(settings, {'other': 42})
 
     def test_read_missing_key_no_default_returns_none(self):
-        from picard.config_upgrade import get_option
-
         settings = {'other': 42}
         result = get_option(settings, 'old_key', option_type=IntOption, default=None)
         self.assertIsNone(result)
 
     def test_read_bool_value(self):
-        from picard.config_upgrade import get_option
-
         settings = {'flag': True}
         result = get_option(settings, 'flag', option_type=BoolOption, default=False)
         self.assertTrue(result)
         self.assertIn('flag', settings)
 
     def test_read_none_value(self):
-        from picard.config_upgrade import get_option
-
         settings = {'tracked': None}
         result = get_option(settings, 'tracked', option_type=Option, default=False)
         self.assertIsNone(result)
 
     def test_read_list_value(self):
-        from picard.config_upgrade import get_option
-
         settings = {'opt1': ['foo', 'bar']}
         result = get_option(settings, 'opt1', option_type=ListOption, default=[])
         self.assertEqual(result, ['foo', 'bar'])
 
     def test_read_enum_value(self):
-        from picard.config_upgrade import get_option
-
         class MyEnum(Enum):
             VALUE1 = 'value1'
             VALUE2 = 'value2'
@@ -343,8 +288,6 @@ class TestGetOption(PicardTestCase):
         self.assertEqual(result, MyEnum.VALUE2)
 
     def test_read_int_enum_value(self):
-        from picard.config_upgrade import get_option
-
         class MyEnum(IntEnum):
             VALUE1 = 1
             VALUE2 = 2
@@ -358,16 +301,12 @@ class TestRemoveOption(PicardTestCase):
     """Tests for the polymorphic remove_option (dict path)."""
 
     def test_remove_existing_key(self):
-        from picard.config_upgrade import remove_option
-
         settings = {'old_key': 'value', 'other': 42}
         remove_option(settings, 'old_key')
         self.assertNotIn('old_key', settings)
         self.assertIn('other', settings)
 
     def test_remove_missing_key_is_noop(self):
-        from picard.config_upgrade import remove_option
-
         settings = {'other': 42}
         remove_option(settings, 'old_key')
         self.assertEqual(settings, {'other': 42})
@@ -377,31 +316,21 @@ class TestWriteOption(PicardTestCase):
     """Tests for the polymorphic write_option (dict path)."""
 
     def test_write_string(self):
-        from picard.config_upgrade import write_option
-
         settings = {}
         write_option(settings, 'key', 'value')
         self.assertEqual(settings, {'key': 'value'})
 
     def test_write_bool(self):
-        from picard.config_upgrade import write_option
-
         settings = {}
         write_option(settings, 'flag', True)
         self.assertEqual(settings, {'flag': True})
 
     def test_write_int(self):
-        from picard.config_upgrade import write_option
-
         settings = {}
         write_option(settings, 'count', 42)
         self.assertEqual(settings, {'count': 42})
 
     def test_write_enum_stores_value(self):
-        from enum import Enum
-
-        from picard.config_upgrade import write_option
-
         class MyEnum(Enum):
             FOO = 'foo'
             BAR = 'bar'
@@ -411,10 +340,6 @@ class TestWriteOption(PicardTestCase):
         self.assertEqual(settings, {'choice': 'foo'})
 
     def test_write_int_enum_stores_value(self):
-        from enum import IntEnum
-
-        from picard.config_upgrade import write_option
-
         class Priority(IntEnum):
             LOW = 1
             HIGH = 2
@@ -424,8 +349,6 @@ class TestWriteOption(PicardTestCase):
         self.assertEqual(settings, {'priority': 2})
 
     def test_write_overwrites_existing(self):
-        from picard.config_upgrade import write_option
-
         settings = {'key': 'old'}
         write_option(settings, 'key', 'new')
         self.assertEqual(settings, {'key': 'new'})

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -41,7 +41,7 @@ from picard.config_upgrade import (
     _UpgradeEntry,
     _UpgradeType,
     apply_settings_upgrades_for_import,
-    get_option,
+    get_option_value,
     remove_option,
     rename_option,
     upgrade_config,
@@ -246,36 +246,36 @@ class TestGetOption(PicardTestCase):
 
     def test_read_existing_key(self):
         settings = {'old_key': 'value', 'other': 42}
-        result = get_option(settings, 'old_key', option_type=TextOption, default='')
+        result = get_option_value(settings, 'old_key', option_type=TextOption, default='')
         self.assertEqual(result, 'value')
         # Key is NOT removed
         self.assertIn('old_key', settings)
 
     def test_read_missing_key_returns_default(self):
         settings = {'other': 42}
-        result = get_option(settings, 'old_key', option_type=TextOption, default='fallback')
+        result = get_option_value(settings, 'old_key', option_type=TextOption, default='fallback')
         self.assertEqual(result, 'fallback')
         self.assertEqual(settings, {'other': 42})
 
     def test_read_missing_key_no_default_returns_none(self):
         settings = {'other': 42}
-        result = get_option(settings, 'old_key', option_type=IntOption, default=None)
+        result = get_option_value(settings, 'old_key', option_type=IntOption, default=None)
         self.assertIsNone(result)
 
     def test_read_bool_value(self):
         settings = {'flag': True}
-        result = get_option(settings, 'flag', option_type=BoolOption, default=False)
+        result = get_option_value(settings, 'flag', option_type=BoolOption, default=False)
         self.assertTrue(result)
         self.assertIn('flag', settings)
 
     def test_read_none_value(self):
         settings = {'tracked': None}
-        result = get_option(settings, 'tracked', option_type=Option, default=False)
+        result = get_option_value(settings, 'tracked', option_type=Option, default=False)
         self.assertIsNone(result)
 
     def test_read_list_value(self):
         settings = {'opt1': ['foo', 'bar']}
-        result = get_option(settings, 'opt1', option_type=ListOption, default=[])
+        result = get_option_value(settings, 'opt1', option_type=ListOption, default=[])
         self.assertEqual(result, ['foo', 'bar'])
 
     def test_read_enum_value(self):
@@ -284,7 +284,7 @@ class TestGetOption(PicardTestCase):
             VALUE2 = 'value2'
 
         settings = {'enum_opt': 'value2'}
-        result = get_option(settings, 'enum_opt', option_type=Option, default=MyEnum.VALUE1)
+        result = get_option_value(settings, 'enum_opt', option_type=Option, default=MyEnum.VALUE1)
         self.assertEqual(result, MyEnum.VALUE2)
 
     def test_read_int_enum_value(self):
@@ -293,7 +293,7 @@ class TestGetOption(PicardTestCase):
             VALUE2 = 2
 
         settings = {'enum_opt': 2}
-        result = get_option(settings, 'enum_opt', option_type=IntOption, default=MyEnum.VALUE1)
+        result = get_option_value(settings, 'enum_opt', option_type=IntOption, default=MyEnum.VALUE1)
         self.assertEqual(result, MyEnum.VALUE2)
 
 

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -21,7 +21,17 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from enum import Enum, IntEnum
+
 from test.picardtestcase import PicardTestCase
+
+from picard.config import (
+    BoolOption,
+    IntOption,
+    ListOption,
+    Option,
+    TextOption,
+)
 
 
 class TestRenameOptionInSettingsPolymorphic(PicardTestCase):
@@ -279,7 +289,7 @@ class TestGetOption(PicardTestCase):
         from picard.config_upgrade import get_option
 
         settings = {'old_key': 'value', 'other': 42}
-        result = get_option(settings, 'old_key')
+        result = get_option(settings, 'old_key', option_type=TextOption, default='')
         self.assertEqual(result, 'value')
         # Key is NOT removed
         self.assertIn('old_key', settings)
@@ -288,7 +298,7 @@ class TestGetOption(PicardTestCase):
         from picard.config_upgrade import get_option
 
         settings = {'other': 42}
-        result = get_option(settings, 'old_key', default='fallback')
+        result = get_option(settings, 'old_key', option_type=TextOption, default='fallback')
         self.assertEqual(result, 'fallback')
         self.assertEqual(settings, {'other': 42})
 
@@ -296,14 +306,14 @@ class TestGetOption(PicardTestCase):
         from picard.config_upgrade import get_option
 
         settings = {'other': 42}
-        result = get_option(settings, 'old_key')
+        result = get_option(settings, 'old_key', option_type=IntOption, default=None)
         self.assertIsNone(result)
 
     def test_read_bool_value(self):
         from picard.config_upgrade import get_option
 
         settings = {'flag': True}
-        result = get_option(settings, 'flag')
+        result = get_option(settings, 'flag', option_type=BoolOption, default=False)
         self.assertTrue(result)
         self.assertIn('flag', settings)
 
@@ -311,8 +321,37 @@ class TestGetOption(PicardTestCase):
         from picard.config_upgrade import get_option
 
         settings = {'tracked': None}
-        result = get_option(settings, 'tracked', default=False)
+        result = get_option(settings, 'tracked', option_type=Option, default=False)
         self.assertIsNone(result)
+
+    def test_read_list_value(self):
+        from picard.config_upgrade import get_option
+
+        settings = {'opt1': ['foo', 'bar']}
+        result = get_option(settings, 'opt1', option_type=ListOption, default=[])
+        self.assertEqual(result, ['foo', 'bar'])
+
+    def test_read_enum_value(self):
+        from picard.config_upgrade import get_option
+
+        class MyEnum(Enum):
+            VALUE1 = 'value1'
+            VALUE2 = 'value2'
+
+        settings = {'enum_opt': 'value2'}
+        result = get_option(settings, 'enum_opt', option_type=Option, default=MyEnum.VALUE1)
+        self.assertEqual(result, MyEnum.VALUE2)
+
+    def test_read_int_enum_value(self):
+        from picard.config_upgrade import get_option
+
+        class MyEnum(IntEnum):
+            VALUE1 = 1
+            VALUE2 = 2
+
+        settings = {'enum_opt': 2}
+        result = get_option(settings, 'enum_opt', option_type=IntOption, default=MyEnum.VALUE1)
+        self.assertEqual(result, MyEnum.VALUE2)
 
 
 class TestRemoveOption(PicardTestCase):

--- a/test/test_config_upgrade_hooks.py
+++ b/test/test_config_upgrade_hooks.py
@@ -21,9 +21,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 import os
+from unittest.mock import patch
 
-import PyQt6.QtCore
-from PyQt6.QtCore import QByteArray
+from PyQt6 import QtCore
 
 from test.test_config import TestPicardConfigCommon
 
@@ -35,6 +35,7 @@ from picard.config import (
     Option,
     TextOption,
 )
+from picard.config_upgrade import _UPGRADES_REGISTRY
 import picard.config_upgrade_hooks as hooks
 from picard.const.cover_processing import ImageFormat
 from picard.const.defaults import (
@@ -44,6 +45,7 @@ from picard.const.defaults import (
     DEFAULT_THEME_NAME,
 )
 from picard.options import StandardizeArtistNames
+from picard.script import get_file_naming_script_presets
 from picard.util import unique_numbered_title
 
 from picard.ui.theme import UiTheme
@@ -52,7 +54,6 @@ from picard.ui.theme import UiTheme
 class TestPicardConfigUpgrades(TestPicardConfigCommon):
     def test_all_hooks_have_tests(self):
         """Ensure every upgrade hook has at least one corresponding test method."""
-        from picard.config_upgrade import _UPGRADES_REGISTRY
 
         def has_test(test_methods, func_name):
             """Check for test_{name} exactly or test_{name}_* (underscore boundary)."""
@@ -315,8 +316,8 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         )
 
     def test_reset_main_splitter_states(self):
-        Option("persist", "splitter_state", QByteArray())
-        Option("persist", "bottom_splitter_state", QByteArray())
+        Option("persist", "splitter_state", QtCore.QByteArray())
+        Option("persist", "bottom_splitter_state", QtCore.QByteArray())
         self.config.persist["splitter_state"] = b'foo'
         self.config.persist["bottom_splitter_state"] = b'bar'
         hooks.reset_main_splitter_states(self.config)
@@ -342,8 +343,6 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertEqual("", self.config.setting["acoustid_fpcalc"])
 
     def test_clear_fpcalc_path_frozen(self):
-        from unittest.mock import patch
-
         TextOption("setting", "acoustid_fpcalc", "")
         self.config.setting["acoustid_fpcalc"] = r"C:\Program Files\MusicBrainz Picard\fpcalc.exe"
         with patch.object(hooks, 'IS_FROZEN', True):
@@ -464,8 +463,6 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertEqual(expected, self.config.setting['toolbar_layout'])
 
     def test_add_preset_naming_scripts(self):
-        from picard.script import get_file_naming_script_presets
-
         Option('setting', 'file_renaming_scripts', {})
         self.config.setting['file_renaming_scripts'] = {}
         hooks.add_preset_naming_scripts(self.config)
@@ -508,8 +505,8 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertTrue(settings['allow_multi_dirs_selection'])
 
     def test_reset_locked_header_states(self):
-        Option('persist', 'album_view_header_state', QByteArray())
-        Option('persist', 'file_view_header_state', QByteArray())
+        Option('persist', 'album_view_header_state', QtCore.QByteArray())
+        Option('persist', 'file_view_header_state', QtCore.QByteArray())
         BoolOption('persist', 'album_view_header_locked', False)
         BoolOption('persist', 'file_view_header_locked', False)
 
@@ -581,8 +578,6 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertFalse(settings['enable_tag_saving'])
 
     def test_remove_old_plugin_options(self):
-        from PyQt6 import QtCore
-
         # Add old plugin options that should be removed
         Option('persist', 'plugins_list_sort_order', QtCore.Qt.SortOrder.AscendingOrder)
         Option('persist', 'plugins_list_sort_section', 0)
@@ -676,8 +671,8 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         self.assertEqual(expected_script, settings['list_of_scripts'][0][3])
 
     def test_remove_persisted_column_config(self):
-        Option('persist', 'album_view_header_state', PyQt6.QtCore.QByteArray())
-        Option('persist', 'file_view_header_state', PyQt6.QtCore.QByteArray())
+        Option('persist', 'album_view_header_state', QtCore.QByteArray())
+        Option('persist', 'file_view_header_state', QtCore.QByteArray())
         self.config.persist['album_view_header_state'] = b'a'
         self.config.persist['file_view_header_state'] = b'a'
 


### PR DESCRIPTION
Some additions to https://github.com/metabrainz/picard/pull/3266 as discussed there:

- Extra type hints
- Renamed get_option to get_option_value and clarified docs
- Support for type conversions in get_option_value to properly support enum and other special types consistently
- Moving inline imports to top