### PR TITLE
Picard 3387/plugin variable autocomplete

### DIFF
--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -160,17 +160,6 @@ def unregister_all_script_variables(api: 'PluginApi') -> None:
     ext_point_script_variables.unregister(api.module_path, lambda item: True)
 
 
-def get_plugin_variable_names() -> set[str]:
-    """Get all plugin-provided variable names.
-
-    Returns
-    -------
-    set[str]
-        Set of variable names provided by plugins
-    """
-    return {var.name for var in ext_point_script_variables}
-
-
 def get_plugin_variable_documentation(name: str) -> str | None:
     """Get documentation for a plugin-provided variable.
 

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -114,7 +114,7 @@ def register_script_variable(
         plugin_id = None
 
     # Remove any existing entry with the same name from this plugin to avoid duplicates
-    ext_point_script_variables.unregister(module_name, lambda item: item.name == name)
+    ext_point_script_variables.unregister(module_name, lambda item: item.name == name and item.is_hidden == is_hidden)
     ext_point_script_variables.register(
         module_name,
         TagVar(

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -126,7 +126,7 @@ def register_script_variable(
             # Locked attributes for plugin-registered variables
             is_preserved=False,
             is_script_variable=True,
-            is_tag=True,
+            is_tag=not is_hidden,
             is_calculated=False,
             is_file_info=False,
             is_from_mb=False,

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -31,9 +31,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections.abc import Iterator
 import re
 
 from picard.const.tags import ALL_TAGS
+from picard.tags.tagvar import TagVar
 
 
 RE_COMMENT_LANG = re.compile('^([a-zA-Z]{3}):')
@@ -86,15 +88,17 @@ def parse_subtag(name):
     return lang, desc
 
 
-def tag_names():
-    """Tag names available for user assignment: built-in tags + plugin-provided tags."""
+def _all_tag_vars() -> Iterator[TagVar]:
     # Inline import to avoid circular dependency: script_variables imports from this module.
     from picard.extension_points.script_variables import ext_point_script_variables
 
-    yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag)
-    for var in ext_point_script_variables:
-        if var.is_tag and not var.is_hidden:
-            yield var.name
+    yield from ALL_TAGS
+    yield from ext_point_script_variables
+
+
+def tag_names():
+    """Tag names available for user assignment: built-in tags + plugin-provided tags."""
+    yield from (var.name for var in _all_tag_vars() if var.is_tag and not var.is_hidden)
 
 
 def visible_tag_names():
@@ -130,13 +134,7 @@ def file_info_tag_names():
 
 def script_variable_tag_names():
     """Tag names available to scripts (used by script editor completer)"""
-    # Inline import to avoid circular dependency: script_variables imports from this module.
-    from picard.extension_points.script_variables import ext_point_script_variables
-
-    yield from (tagvar.script_name() for tagvar in ALL_TAGS if tagvar.is_script_variable)
-    for var in ext_point_script_variables:
-        if var.is_script_variable:
-            yield var.script_name()
+    yield from (var.script_name() for var in _all_tag_vars() if var.is_script_variable)
 
 
 def display_tag_name(name):

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -101,14 +101,6 @@ def tag_names():
     yield from (var.name for var in _all_tag_vars() if var.is_tag and not var.is_hidden)
 
 
-def visible_tag_names():
-    yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag and not tv.is_hidden)
-
-
-def hidden_tag_names():
-    yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag and tv.is_hidden)
-
-
 def filterable_tag_names():
     yield from ALL_TAGS.names(selector=lambda tv: tv.is_filterable)
 

--- a/picard/ui/widgets/completion_provider.py
+++ b/picard/ui/widgets/completion_provider.py
@@ -21,7 +21,6 @@
 """Completion choices provider for script completion."""
 
 from collections.abc import (
-    Callable,
     Iterable,
     Iterator,
 )
@@ -49,15 +48,12 @@ class CompletionChoicesProvider:
 
     Attributes
     ----------
-    _get_plugin_variable_names : Callable[[], set[str]]
-        Function that returns a set of plugin variable names.
     _user_script_scanner : UserScriptScanner | None
         User script scanner for extracting variables from user scripts.
     """
 
     def __init__(
         self,
-        get_plugin_variable_names: Callable[[], set[str]],
         user_script_scanner: UserScriptScanner | None = None,
     ):
         """Initialize the completion choices provider.
@@ -69,7 +65,6 @@ class CompletionChoicesProvider:
         user_script_scanner : UserScriptScanner | None
             Optional user script scanner for extracting variables from user scripts.
         """
-        self._get_plugin_variable_names = get_plugin_variable_names
         self._user_script_scanner = user_script_scanner
 
     def build_choices(
@@ -105,7 +100,6 @@ class CompletionChoicesProvider:
         - TAG_NAME_ARG: Returns variable names without formatting
         - DEFAULT/VARIABLE: Returns variable names with % prefix and suffix
         """
-        plugin_variables = self._get_plugin_variable_names()
         builtin_variables = set(builtin_variables)
 
         # Get user script variables if scanner is available
@@ -116,7 +110,7 @@ class CompletionChoicesProvider:
                 if cached_variables is not None:
                     user_script_variables = cached_variables
 
-        all_variables = list(builtin_variables | user_defined_variables | plugin_variables | user_script_variables)
+        all_variables = list(builtin_variables | user_defined_variables | user_script_variables)
         all_variables.sort(key=lambda x: (-usage_counts.get(x, 0), x))
 
         if mode in (CompletionMode.DEFAULT, CompletionMode.FUNCTION_NAME):

--- a/picard/ui/widgets/scripttextedit.py
+++ b/picard/ui/widgets/scripttextedit.py
@@ -23,7 +23,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-from collections.abc import Callable
 import contextlib
 import re
 import unicodedata
@@ -47,7 +46,6 @@ from PyQt6.QtWidgets import (
 
 from picard.config import get_config
 from picard.const.sys import IS_MACOS
-from picard.extension_points.script_variables import get_plugin_variable_names
 from picard.i18n import gettext as _
 from picard.script import (
     ScriptFunctionDocError,
@@ -199,7 +197,6 @@ class ScriptCompleter(QCompleter):
         parser: ScriptParser | None = None,
         variable_extractor: VariableExtractor | None = None,
         context_detector: ContextDetector | None = None,
-        plugin_variable_provider: Callable[[], set[str]] | None = None,
         choices_provider: CompletionChoicesProvider | None = None,
         user_script_scanner: UserScriptScanner | None = None,
     ):
@@ -229,10 +226,7 @@ class ScriptCompleter(QCompleter):
         self.highlighted.connect(self.set_highlighted)
 
         # IOC for plugin variables and choices provider
-        self._plugin_variable_provider = plugin_variable_provider or get_plugin_variable_names
-        self._choices_provider = choices_provider or CompletionChoicesProvider(
-            self._plugin_variable_provider, self._user_script_scanner
-        )
+        self._choices_provider = choices_provider or CompletionChoicesProvider(self._user_script_scanner)
 
         # Initialize the model with initial choices
         self._model.setStringList(list(self.choices))

--- a/test/script_text_edit/test_completion_choices_provider.py
+++ b/test/script_text_edit/test_completion_choices_provider.py
@@ -25,9 +25,7 @@ to handle completion choices generation with proper ordering, mode handling,
 deduplication, and error handling.
 """
 
-from collections.abc import Callable
 from unittest.mock import (
-    Mock,
     patch,
 )
 
@@ -38,15 +36,9 @@ from picard.ui.widgets.context_detector import CompletionMode
 
 
 @pytest.fixture
-def mock_plugin_provider() -> Mock:
-    """Create a mock plugin variable provider."""
-    return Mock(return_value={'plugin_var1', 'plugin_var2', 'plugin_var3'})
-
-
-@pytest.fixture
-def choices_provider(mock_plugin_provider: Mock) -> CompletionChoicesProvider:
+def choices_provider() -> CompletionChoicesProvider:
     """Create a CompletionChoicesProvider instance for testing."""
-    return CompletionChoicesProvider(mock_plugin_provider)
+    return CompletionChoicesProvider()
 
 
 @pytest.fixture
@@ -71,30 +63,6 @@ def sample_builtin_variables() -> list[str]:
 def sample_user_variables() -> set[str]:
     """Sample user-defined variables for testing."""
     return {'user_var1', 'user_var2', 'artist'}  # 'artist' overlaps with builtin
-
-
-class TestCompletionChoicesProviderInitialization:
-    """Test CompletionChoicesProvider initialization."""
-
-    def test_initialization_with_provider(self, mock_plugin_provider: Callable[[], set[str]]) -> None:
-        """Test initialization with plugin provider."""
-        provider = CompletionChoicesProvider(mock_plugin_provider)
-        assert provider._get_plugin_variable_names is mock_plugin_provider
-
-    def test_plugin_provider_integration(self, mock_plugin_provider: Callable[[], set[str]]) -> None:
-        """Test that plugin provider is integrated correctly."""
-        # Create a fresh provider to avoid calls during fixture creation
-        provider = CompletionChoicesProvider(mock_plugin_provider)
-
-        # Test that plugin variables are included in the results
-        choices = list(provider.build_choices(CompletionMode.VARIABLE, set(), [], {}))
-
-        # Should include plugin variables
-        plugin_choices = [choice for choice in choices if 'plugin_var' in choice]
-        assert len(plugin_choices) > 0
-        assert any('plugin_var1' in choice for choice in choices)
-        assert any('plugin_var2' in choice for choice in choices)
-        assert any('plugin_var3' in choice for choice in choices)
 
 
 class TestCompletionChoicesProviderOrdering:
@@ -127,11 +95,8 @@ class TestCompletionChoicesProviderOrdering:
             'artist',  # 5 uses
             'user_var1',  # 4 uses
             'album',  # 3 uses
-            'plugin_var1',  # 2 uses
             'title',  # 1 use
             'date',  # 0 uses
-            'plugin_var2',  # 0 uses
-            'plugin_var3',  # 0 uses
             'user_var2',  # 0 uses
         ]
 
@@ -249,9 +214,6 @@ class TestCompletionChoicesProviderModes:
             'date',
             'user_var1',
             'user_var2',
-            'plugin_var1',
-            'plugin_var2',
-            'plugin_var3',
         }
         actual_names = set(choices)
         assert actual_names == expected_names
@@ -282,30 +244,6 @@ class TestCompletionChoicesProviderModes:
 class TestCompletionChoicesProviderDeduplication:
     """Test deduplication across builtin/plugin/user variables."""
 
-    def test_deduplication_builtin_plugin_overlap(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test deduplication when builtin and plugin variables overlap."""
-        # Mock plugin provider to return overlapping variables
-        choices_provider._get_plugin_variable_names.return_value = {'artist', 'plugin_var'}  # type: ignore
-
-        choices = list(
-            choices_provider.build_choices(
-                CompletionMode.VARIABLE,
-                set(),
-                ['artist', 'album'],
-                {},
-            )
-        )
-
-        # Should not have duplicates
-        var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
-        assert len(var_names) == len(set(var_names))
-        assert 'artist' in var_names
-        assert 'album' in var_names
-        assert 'plugin_var' in var_names
-
     def test_deduplication_user_builtin_overlap(
         self,
         choices_provider: CompletionChoicesProvider,
@@ -323,26 +261,6 @@ class TestCompletionChoicesProviderDeduplication:
         var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
         assert len(var_names) == len(set(var_names))
         assert var_names.count('artist') == 1  # Should appear only once
-
-    def test_deduplication_user_plugin_overlap(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test deduplication when user and plugin variables overlap."""
-        choices_provider._get_plugin_variable_names.return_value = {'plugin_var', 'user_var'}  # type: ignore
-
-        choices = list(
-            choices_provider.build_choices(
-                CompletionMode.VARIABLE,
-                {'user_var', 'other_user_var'},
-                [],
-                {},
-            )
-        )
-
-        var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
-        assert len(var_names) == len(set(var_names))
-        assert var_names.count('user_var') == 1  # Should appear only once
 
     def test_stable_output_with_equal_weights(
         self,
@@ -379,8 +297,6 @@ class TestCompletionChoicesProviderErrorHandling:
         choices_provider: CompletionChoicesProvider,
     ) -> None:
         """Test handling when plugin provider returns empty set."""
-        choices_provider._get_plugin_variable_names.return_value = set()  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
@@ -394,40 +310,6 @@ class TestCompletionChoicesProviderErrorHandling:
         assert 'user_var' in var_names
         assert 'builtin_var' in var_names
         # No plugin variables should be present
-
-    def test_plugin_provider_raises_exception(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test handling when plugin provider raises exception."""
-        choices_provider._get_plugin_variable_names.side_effect = RuntimeError("Plugin error")  # type: ignore
-
-        with pytest.raises(RuntimeError, match="Plugin error"):
-            list(
-                choices_provider.build_choices(
-                    CompletionMode.VARIABLE,
-                    {'user_var'},
-                    ['builtin_var'],
-                    {},
-                )
-            )
-
-    def test_plugin_provider_returns_none(
-        self,
-        choices_provider: CompletionChoicesProvider,
-    ) -> None:
-        """Test handling when plugin provider returns None."""
-        choices_provider._get_plugin_variable_names.return_value = None  # type: ignore
-
-        with pytest.raises(TypeError):
-            list(
-                choices_provider.build_choices(
-                    CompletionMode.VARIABLE,
-                    {'user_var'},
-                    ['builtin_var'],
-                    {},
-                )
-            )
 
     def test_empty_inputs(
         self,
@@ -445,8 +327,7 @@ class TestCompletionChoicesProviderErrorHandling:
 
         # Should only contain plugin variables
         var_names = [choice[1:-1] for choice in choices if choice.startswith('%') and choice.endswith('%')]
-        expected_plugin_vars = {'plugin_var1', 'plugin_var2', 'plugin_var3'}
-        assert set(var_names) == expected_plugin_vars
+        assert set(var_names) == set()
 
 
 class TestCompletionChoicesProviderEdgeCases:
@@ -457,12 +338,10 @@ class TestCompletionChoicesProviderEdgeCases:
         choices_provider: CompletionChoicesProvider,
     ) -> None:
         """Test handling of unicode variable names."""
-        choices_provider._get_plugin_variable_names.return_value = {'var_ñ', 'var_中文'}  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
-                set(),
+                {'var_ñ', 'var_中文'},
                 [],
                 {},
             )
@@ -477,12 +356,10 @@ class TestCompletionChoicesProviderEdgeCases:
         choices_provider: CompletionChoicesProvider,
     ) -> None:
         """Test handling of variable names with colons."""
-        choices_provider._get_plugin_variable_names.return_value = {'tag:artist', 'tag:album'}  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
-                set(),
+                {'tag:artist', 'tag:album'},
                 [],
                 {},
             )
@@ -498,12 +375,10 @@ class TestCompletionChoicesProviderEdgeCases:
     ) -> None:
         """Test handling of very long variable names."""
         long_name = 'a' * 1000
-        choices_provider._get_plugin_variable_names.return_value = {long_name}  # type: ignore
-
         choices = list(
             choices_provider.build_choices(
                 CompletionMode.VARIABLE,
-                set(),
+                {long_name},
                 [],
                 {},
             )

--- a/test/script_text_edit/test_completion_provider_user_scripts.py
+++ b/test/script_text_edit/test_completion_provider_user_scripts.py
@@ -34,12 +34,6 @@ from picard.ui.widgets.user_script_scanner import UserScriptScanner
 
 
 @pytest.fixture
-def mock_plugin_provider():
-    """Create a mock plugin variable provider."""
-    return Mock(return_value={'plugin_var1', 'plugin_var2'})
-
-
-@pytest.fixture
 def mock_user_script_scanner():
     """Create a mock user script scanner."""
     scanner = Mock(spec=UserScriptScanner)
@@ -48,28 +42,26 @@ def mock_user_script_scanner():
 
 
 @pytest.fixture
-def choices_provider_with_scanner(mock_plugin_provider, mock_user_script_scanner):
+def choices_provider_with_scanner(mock_user_script_scanner):
     """Create a CompletionChoicesProvider with user script scanner."""
-    return CompletionChoicesProvider(mock_plugin_provider, mock_user_script_scanner)
+    return CompletionChoicesProvider(mock_user_script_scanner)
 
 
 @pytest.fixture
-def choices_provider_without_scanner(mock_plugin_provider):
+def choices_provider_without_scanner():
     """Create a CompletionChoicesProvider without user script scanner."""
-    return CompletionChoicesProvider(mock_plugin_provider)
+    return CompletionChoicesProvider()
 
 
-def test_initialization_with_user_script_scanner(mock_plugin_provider, mock_user_script_scanner):
+def test_initialization_with_user_script_scanner(mock_user_script_scanner):
     """Test initialization with user script scanner."""
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_user_script_scanner)
-    assert provider._get_plugin_variable_names is mock_plugin_provider
+    provider = CompletionChoicesProvider(mock_user_script_scanner)
     assert provider._user_script_scanner is mock_user_script_scanner
 
 
-def test_initialization_without_user_script_scanner(mock_plugin_provider):
+def test_initialization_without_user_script_scanner():
     """Test initialization without user script scanner."""
-    provider = CompletionChoicesProvider(mock_plugin_provider)
-    assert provider._get_plugin_variable_names is mock_plugin_provider
+    provider = CompletionChoicesProvider()
     assert provider._user_script_scanner is None
 
 
@@ -89,8 +81,6 @@ def test_build_choices_includes_user_script_variables(choices_provider_with_scan
     assert '%user_script_var2%' in choices
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
-    assert '%plugin_var2%' in choices
 
 
 def test_build_choices_without_user_script_scanner(choices_provider_without_scanner):
@@ -109,8 +99,6 @@ def test_build_choices_without_user_script_scanner(choices_provider_without_scan
     assert '%user_script_var2%' not in choices
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
-    assert '%plugin_var2%' in choices
 
 
 def test_build_choices_deduplication_with_user_scripts(choices_provider_with_scanner):
@@ -183,18 +171,16 @@ def test_build_choices_tag_name_arg_mode_with_user_scripts(choices_provider_with
         'user_script_var2',
         'user_defined_var',
         'builtin_var',
-        'plugin_var1',
-        'plugin_var2',
     }
     actual_names = set(choices)
     assert actual_names == expected_names
 
 
-def test_build_choices_user_script_scanner_exception(mock_plugin_provider):
+def test_build_choices_user_script_scanner_exception():
     """Test handling when user script scanner raises exception."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.side_effect = AttributeError("Scanner error")
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     # Should not raise exception
     choices = list(
@@ -209,14 +195,13 @@ def test_build_choices_user_script_scanner_exception(mock_plugin_provider):
     # Should still include other variables
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
 
 
-def test_build_choices_user_script_scanner_returns_none(mock_plugin_provider):
+def test_build_choices_user_script_scanner_returns_none():
     """Test handling when user script scanner returns None."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = None
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     # Should not raise exception
     choices = list(
@@ -231,14 +216,13 @@ def test_build_choices_user_script_scanner_returns_none(mock_plugin_provider):
     # Should still include other variables
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
 
 
-def test_build_choices_empty_user_script_variables(mock_plugin_provider):
+def test_build_choices_empty_user_script_variables():
     """Test handling when user script scanner returns empty set."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = set()
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     choices = list(
         provider.build_choices(
@@ -252,15 +236,14 @@ def test_build_choices_empty_user_script_variables(mock_plugin_provider):
     # Should include other variables but not user script variables
     assert '%user_defined_var%' in choices
     assert '%builtin_var%' in choices
-    assert '%plugin_var1%' in choices
     assert '%user_script_var1%' not in choices
 
 
-def test_build_choices_unicode_user_script_variables(mock_plugin_provider):
+def test_build_choices_unicode_user_script_variables():
     """Test handling of unicode user script variable names."""
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = {'var_ñ', 'var_中文'}
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     choices = list(
         provider.build_choices(
@@ -275,12 +258,12 @@ def test_build_choices_unicode_user_script_variables(mock_plugin_provider):
     assert '%var_中文%' in choices
 
 
-def test_build_choices_very_long_user_script_variables(mock_plugin_provider):
+def test_build_choices_very_long_user_script_variables():
     """Test handling of very long user script variable names."""
     long_name = 'a' * 1000
     mock_scanner = Mock(spec=UserScriptScanner)
     mock_scanner.get_cached_variables.return_value = {long_name}
-    provider = CompletionChoicesProvider(mock_plugin_provider, mock_scanner)
+    provider = CompletionChoicesProvider(mock_scanner)
 
     choices = list(
         provider.build_choices(

--- a/test/script_text_edit/test_script_completer_ioc.py
+++ b/test/script_text_edit/test_script_completer_ioc.py
@@ -25,7 +25,6 @@ that injected dependencies are used correctly and model reuse works
 as expected.
 """
 
-from collections.abc import Callable
 from unittest.mock import Mock
 
 from picard.script.parser import ScriptParser
@@ -66,13 +65,6 @@ def mock_context_detector() -> Mock:
 
 
 @pytest.fixture
-def mock_plugin_variable_provider() -> Callable[[], set[str]]:
-    """Create a mock plugin variable provider."""
-    provider = Mock(return_value={'plugin_var1', 'plugin_var2'})
-    return provider
-
-
-@pytest.fixture
 def mock_choices_provider() -> Mock:
     """Create a mock CompletionChoicesProvider."""
     provider = Mock(spec=CompletionChoicesProvider)
@@ -86,7 +78,6 @@ def script_completer_with_injections(
     mock_parser: Mock,
     mock_variable_extractor: Mock,
     mock_context_detector: Mock,
-    mock_plugin_variable_provider: Callable[[], set[str]],
     mock_choices_provider: Mock,
 ) -> ScriptCompleter:
     """Create a ScriptCompleter with all dependencies injected."""
@@ -94,7 +85,6 @@ def script_completer_with_injections(
         parser=mock_parser,
         variable_extractor=mock_variable_extractor,
         context_detector=mock_context_detector,
-        plugin_variable_provider=mock_plugin_variable_provider,
         choices_provider=mock_choices_provider,
     )
 
@@ -126,14 +116,6 @@ class TestScriptCompleterDependencyInjection:
         """Test that injected context detector is used."""
         assert script_completer_with_injections._context_detector is mock_context_detector
 
-    def test_uses_injected_plugin_provider(
-        self,
-        script_completer_with_injections: ScriptCompleter,
-        mock_plugin_variable_provider: Callable[[], set[str]],
-    ) -> None:
-        """Test that injected plugin provider is used."""
-        assert script_completer_with_injections._plugin_variable_provider is mock_plugin_variable_provider
-
     def test_uses_injected_choices_provider(
         self,
         script_completer_with_injections: ScriptCompleter,
@@ -150,7 +132,6 @@ class TestScriptCompleterDependencyInjection:
         assert isinstance(completer._parser, ScriptParser)
         assert isinstance(completer._variable_extractor, VariableExtractor)
         assert isinstance(completer._context_detector, ContextDetector)
-        assert completer._plugin_variable_provider is not None
         assert isinstance(completer._choices_provider, CompletionChoicesProvider)
 
     def test_variable_extractor_uses_injected_parser(
@@ -351,11 +332,7 @@ class TestScriptCompleterIntegration:
         # Should get choices for the context
         assert isinstance(choices, list)
 
-    def test_plugin_provider_integration(
-        self,
-        script_completer_with_injections: ScriptCompleter,
-        mock_plugin_variable_provider: Callable[[], set[str]],
-    ) -> None:
+    def test_plugin_provider_integration(self, script_completer_with_injections: ScriptCompleter) -> None:
         """Test integration between completer and plugin provider."""
         # Generate choices
         choices = list(script_completer_with_injections.choices)
@@ -392,7 +369,6 @@ class TestScriptCompleterEdgeCases:
             parser=None,
             variable_extractor=None,
             context_detector=None,
-            plugin_variable_provider=None,
             choices_provider=None,
         )
 
@@ -400,7 +376,6 @@ class TestScriptCompleterEdgeCases:
         assert completer._parser is not None
         assert completer._variable_extractor is not None
         assert completer._context_detector is not None
-        assert completer._plugin_variable_provider is not None
         assert completer._choices_provider is not None
 
     def test_handles_empty_script_content(

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -34,7 +34,6 @@ from picard.extension_points import (
 )
 from picard.extension_points.script_variables import (
     get_plugin_variable_documentation,
-    get_plugin_variable_names,
     register_script_variable,
     unregister_all_script_variables,
     unregister_script_variable,
@@ -237,22 +236,25 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api.manifest.name_i18n.return_value = name
         return api
 
+    def _registered_variable_names(self):
+        return set(var.name for var in self.ext_point)
+
     def test_register_script_variable(self):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
-        self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
+        self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
         self.assertEqual('some docs', get_plugin_variable_documentation('my_var1'))
 
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
-        self.assertEqual({'my_var1'}, get_plugin_variable_names())
+        self.assertEqual({'my_var1'}, self._registered_variable_names())
         self.assertIsNone(get_plugin_variable_documentation('my_var1'))
 
     def test_register_script_variable_with_api(self):
         api = self._make_api()
         register_script_variable('my_var1', 'Some docs', api)
         register_script_variable('my_var2', api=api)
-        self.assertEqual({'my_var1', 'my_var2'}, get_plugin_variable_names())
+        self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
         self.assertEqual('Some docs', get_plugin_variable_documentation('my_var1'))
         self.assertIsNone(get_plugin_variable_documentation('my_var2'))
 
@@ -303,7 +305,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api = self._make_api()
         register_script_variable('my_var', 'First docs', api)
         register_script_variable('my_var', 'Updated docs', api)
-        self.assertEqual({'my_var'}, get_plugin_variable_names())
+        self.assertEqual({'my_var'}, self._registered_variable_names())
         self.assertEqual('Updated docs', get_plugin_variable_documentation('my_var'))
 
     def test_register_same_variable_different_plugins(self):
@@ -312,7 +314,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api2 = self._make_api('picard.plugins.plugin2', 'Plugin Two')
         register_script_variable('shared_var', 'Docs from plugin1', api1)
         register_script_variable('shared_var', 'Docs from plugin2', api2)
-        self.assertEqual({'shared_var'}, get_plugin_variable_names())
+        self.assertEqual({'shared_var'}, self._registered_variable_names())
         self.assertEqual('Docs from plugin1', get_plugin_variable_documentation('shared_var'))
 
     def test_unregister_script_variable(self):
@@ -320,9 +322,9 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         api = self._make_api()
         register_script_variable('var1', 'Docs 1', api)
         register_script_variable('var2', 'Docs 2', api)
-        self.assertEqual({'var1', 'var2'}, get_plugin_variable_names())
+        self.assertEqual({'var1', 'var2'}, self._registered_variable_names())
         unregister_script_variable('var1', api)
-        self.assertEqual({'var2'}, get_plugin_variable_names())
+        self.assertEqual({'var2'}, self._registered_variable_names())
 
     def test_unregister_script_variable_nonexistent(self):
         """Unregistering a variable that doesn't exist should not raise."""
@@ -335,9 +337,9 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('var1', 'Docs 1', api)
         register_script_variable('var2', 'Docs 2', api)
         register_script_variable('var3', 'Docs 3', api)
-        self.assertEqual({'var1', 'var2', 'var3'}, get_plugin_variable_names())
+        self.assertEqual({'var1', 'var2', 'var3'}, self._registered_variable_names())
         unregister_all_script_variables(api)
-        self.assertEqual(set(), get_plugin_variable_names())
+        self.assertEqual(set(), self._registered_variable_names())
 
     def test_unregister_all_does_not_affect_other_plugins(self):
         """Unregistering all variables from one plugin should not affect another."""
@@ -346,7 +348,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('var_from_p1', 'Docs', api1)
         register_script_variable('var_from_p2', 'Docs', api2)
         unregister_all_script_variables(api1)
-        self.assertEqual({'var_from_p2'}, get_plugin_variable_names())
+        self.assertEqual({'var_from_p2'}, self._registered_variable_names())
 
     def test_unregister_does_not_affect_other_plugins(self):
         """Unregistering a variable name should only remove it from the calling plugin."""
@@ -355,7 +357,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from p1', api1)
         register_script_variable('shared_var', 'Docs from p2', api2)
         unregister_script_variable('shared_var', api1)
-        self.assertEqual({'shared_var'}, get_plugin_variable_names())
+        self.assertEqual({'shared_var'}, self._registered_variable_names())
         self.assertEqual('Docs from p2', get_plugin_variable_documentation('shared_var'))
 
     def test_extension_point_unregister_with_match(self):

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -40,6 +40,7 @@ from picard.extension_points.script_variables import (
 )
 from picard.plugin3.manager import PluginManager
 from picard.plugin3.plugin import Plugin
+from picard.tags.tagvar import TagVar
 
 
 def create_mock_plugin(uuid, plugin_id='testplugin') -> Plugin:
@@ -220,7 +221,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         super().setUp()
         patcher_ep = patch(
             'picard.extension_points.script_variables.ext_point_script_variables',
-            ExtensionPoint(label='test_variables'),
+            ExtensionPoint[TagVar](label='test_variables'),
         )
         patcher_config = patch('picard.extension_points.get_config', return_value=None)
         self.ext_point = patcher_ep.start()
@@ -239,11 +240,21 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
     def _registered_variable_names(self):
         return set(var.name for var in self.ext_point)
 
+    def _get_tagvar_by_name(self, name) -> TagVar:
+        for var in self.ext_point:
+            if var.name == name:
+                return var
+        raise ValueError(f'Variable "{name}" not found in extension point')
+
     def test_register_script_variable(self):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
         self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
         self.assertEqual('some docs', get_plugin_variable_documentation('my_var1'))
+        var = self._get_tagvar_by_name('my_var1')
+        self.assertTrue(var.is_tag)
+        self.assertFalse(var.is_hidden)
+        self.assertFalse(var.is_multi_value)
 
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
@@ -271,34 +282,23 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         """Registered TagVar should carry the plugin_id from the API."""
         api = self._make_api()
         register_script_variable('my_var', 'docs', api)
-        for var in self.ext_point:
-            if var.name == 'my_var':
-                self.assertEqual('testplugin', var.plugin_id)
-                break
-        else:
-            self.fail("Variable not found in extension point")
+        var = self._get_tagvar_by_name('my_var')
+        self.assertEqual('testplugin', var.plugin_id)
 
     def test_register_script_variable_is_hidden(self):
         """Names starting with _ should be registered as hidden variables."""
         register_script_variable('_hidden_var', 'docs')
-        for var in self.ext_point:
-            if var.name == 'hidden_var':
-                self.assertTrue(var.is_hidden)
-                self.assertEqual('~hidden_var', str(var))
-                self.assertEqual('_hidden_var', var.script_name())
-                break
-        else:
-            self.fail("Variable not found in extension point")
+        var = self._get_tagvar_by_name('hidden_var')
+        self.assertTrue(var.is_hidden)
+        self.assertFalse(var.is_tag)
+        self.assertEqual('~hidden_var', str(var))
+        self.assertEqual('_hidden_var', var.script_name())
 
     def test_register_script_variable_is_multi_value(self):
         """is_multi_value parameter should be passed through to the TagVar."""
         register_script_variable('multi_var', 'docs', is_multi_value=True)
-        for var in self.ext_point:
-            if var.name == 'multi_var':
-                self.assertTrue(var.is_multi_value)
-                break
-        else:
-            self.fail("Variable not found in extension point")
+        var = self._get_tagvar_by_name('multi_var')
+        self.assertTrue(var.is_multi_value)
 
     def test_register_script_variable_deduplication(self):
         """Registering the same variable twice from the same plugin should update, not duplicate."""

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -39,13 +39,11 @@ from picard.profile import profile_groups_add_setting
 from picard.tags import (
     display_tag_name,
     filterable_tag_names,
-    hidden_tag_names,
     parse_comment_tag,
     parse_subtag,
     preserved_tag_names,
     script_variable_tag_names,
     tag_names,
-    visible_tag_names,
 )
 from picard.tags.docs import (
     display_tag_full_description,
@@ -617,20 +615,6 @@ class TagsGeneratorTest(PicardTestCase):
 
         for tag in tags:
             self.assertTrue(ALL_TAGS.tagvar_from_name(tag).is_tag)
-
-    def test_all_visible_tags(self):
-        tags = list(visible_tag_names())
-        self.assertTrue(len(tags) > 0)
-
-        for tag in tags:
-            self.assertFalse(ALL_TAGS.tagvar_from_name(tag).is_hidden)
-
-    def test_all_hidden_tags(self):
-        tags = list(hidden_tag_names())
-        self.assertTrue(len(tags) > 0)
-
-        for tag in tags:
-            self.assertTrue(ALL_TAGS.tagvar_from_name(tag).is_hidden)
 
     def test_all_preserved_tags(self):
         tags = list(preserved_tag_names())


### PR DESCRIPTION
This fixes two issues atop https://github.com/metabrainz/picard/pull/3351/

1. Since plugin names are registered with the name having the underscore prefix removed, registering the same name as both hidden and non-hidden did count as the same variable. 3b68557f24277fa8022c4201a3ed8c2d6b77b504
2. The script editor `CompletionProvider` can now be simplified to, as there is no special handling of plugin variables needed. This simplifies code and tests. But also fixes an issue where the script editor would offer autocompletion for a hidden plugin variable both with and without underscore.