### PR TITLE
Fixed hidden script variable not showing tooltip in editor

### DIFF
--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -109,9 +109,11 @@ def register_script_variable(
     if api:
         module_name = api.module_path
         plugin_id = api.plugin_id
+        plugin_name = api.manifest.name_i18n()
     else:
         module_name = 'unknown'
         plugin_id = None
+        plugin_name = None
 
     # Reject registering the same base name with a different is_hidden status.
     # A plugin cannot register both 'foo' and '_foo' — the base name must be unique.
@@ -145,6 +147,7 @@ def register_script_variable(
             is_from_mb=False,
             is_populated_by_picard=False,
             plugin_id=plugin_id,
+            plugin_name=plugin_name,
         ),
     )
 
@@ -171,25 +174,6 @@ def unregister_all_script_variables(api: 'PluginApi') -> None:
         The plugin API instance (identifies which plugin's registrations to remove)
     """
     ext_point_script_variables.unregister(api.module_path, lambda item: True)
-
-
-def get_plugin_variable_documentation(name: str) -> str | None:
-    """Get documentation for a plugin-provided variable.
-
-    Parameters
-    ----------
-    name : str
-        The variable name (bare name without prefix)
-
-    Returns
-    -------
-    str or None
-        Documentation string if available, None otherwise
-    """
-    for var in ext_point_script_variables:
-        if var.script_name() == name:
-            return var._longdesc
-    return None
 
 
 def get_plugin_variable_title(name: str) -> str | None:

--- a/picard/extension_points/script_variables.py
+++ b/picard/extension_points/script_variables.py
@@ -187,7 +187,7 @@ def get_plugin_variable_documentation(name: str) -> str | None:
         Documentation string if available, None otherwise
     """
     for var in ext_point_script_variables:
-        if var.name == name:
+        if var.script_name() == name:
             return var._longdesc
     return None
 
@@ -206,6 +206,6 @@ def get_plugin_variable_title(name: str) -> str | None:
         Display title if available, None otherwise
     """
     for var in ext_point_script_variables:
-        if var.name == name:
+        if var.script_name() == name:
             return var._shortdesc
     return None

--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -88,7 +88,7 @@ def parse_subtag(name):
     return lang, desc
 
 
-def _all_tag_vars() -> Iterator[TagVar]:
+def all_tag_vars() -> Iterator[TagVar]:
     # Inline import to avoid circular dependency: script_variables imports from this module.
     from picard.extension_points.script_variables import ext_point_script_variables
 
@@ -98,7 +98,7 @@ def _all_tag_vars() -> Iterator[TagVar]:
 
 def tag_names():
     """Tag names available for user assignment: built-in tags + plugin-provided tags."""
-    yield from (var.name for var in _all_tag_vars() if var.is_tag and not var.is_hidden)
+    yield from (var.name for var in all_tag_vars() if var.is_tag and not var.is_hidden)
 
 
 def filterable_tag_names():
@@ -126,7 +126,7 @@ def file_info_tag_names():
 
 def script_variable_tag_names():
     """Tag names available to scripts (used by script editor completer)"""
-    yield from (var.script_name() for var in _all_tag_vars() if var.is_script_variable)
+    yield from (var.script_name() for var in all_tag_vars() if var.is_script_variable)
 
 
 def display_tag_name(name):

--- a/picard/tags/docs.py
+++ b/picard/tags/docs.py
@@ -20,38 +20,47 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 from picard.const.tags import ALL_TAGS
-from picard.extension_points.script_variables import get_plugin_variable_documentation
 from picard.i18n import gettext as _
+from picard.tags import all_tag_vars
 from picard.tags.tagvar import (
     TEXT_NO_DESCRIPTION,
+    TagVar,
     _markdown,
 )
 
 
 def display_tag_tooltip(tagname):
-    name, tagdesc, _search_name, item = ALL_TAGS.item_from_name(tagname)
+    name, item, tagdesc = _get_tagvar_item(tagname)
     content = ALL_TAGS.tooltip_content(item) if item else None
-    return _finalize_content(name, content, tagdesc)
+    return _finalize_tooltip_content(name, content, tagdesc)
 
 
-def display_tag_full_description(tagname):
-    name, tagdesc, _search_name, item = ALL_TAGS.item_from_name(tagname)
+def display_tag_full_description(item: TagVar) -> str:
     content = ALL_TAGS.full_description_content(item) if item else None
-    return _finalize_content(name, content, tagdesc)
-
-
-def display_plugin_tag_full_description(name, description):
-    content = _markdown(description or _(TEXT_NO_DESCRIPTION))
-    return _format_display(name, content, '')
-
-
-def _finalize_content(name, content, tagdesc):
     if not content:
-        content = _markdown(get_plugin_variable_documentation(name) or _(TEXT_NO_DESCRIPTION))
-    return _format_display(name, content, tagdesc)
+        content = _markdown(_(TEXT_NO_DESCRIPTION))
+    return content
 
 
-def _format_display(name, content, tagdesc):
+def _get_tagvar_item(tagname):
+    if ':' in tagname:
+        tagname, tagdesc = tagname.split(':', 1)
+    else:
+        tagdesc = None
+
+    item = next((var for var in all_tag_vars() if var.name == tagname.lstrip('~_')), None)
+    if item:
+        return item.script_name(), item, tagdesc
+    return tagname, None, None
+
+
+def _finalize_tooltip_content(name, content, tagdesc=None):
+    if not content:
+        content = _markdown(_(TEXT_NO_DESCRIPTION))
+    return _format_tooltip(name, content, tagdesc)
+
+
+def _format_tooltip(name, content, tagdesc=None):
     fmt_tagdesc = _("<p><em>%{name}%</em> [{tagdesc}]</p>{content}")
     fmt_normal = _("<p><em>%{name}%</em></p>{content}")
     fmt = fmt_tagdesc if tagdesc else fmt_normal

--- a/picard/tags/tagvar.py
+++ b/picard/tags/tagvar.py
@@ -60,6 +60,7 @@ class Section(IntEnum):
     options = 2
     links = 3
     see_also = 4
+    plugin_info = 5
 
 
 SectionInfo = namedtuple('SectionInfo', ('title', 'tagvar_func'))
@@ -68,6 +69,7 @@ SECTIONS = {
     Section.options: SectionInfo(N_('Option Settings'), 'related_options_titles'),
     Section.links: SectionInfo(N_('Links'), 'links'),
     Section.see_also: SectionInfo(N_('See Also'), 'see_alsos'),
+    Section.plugin_info: SectionInfo(N_('Plugin'), 'plugin_info'),
 }
 
 TEXT_NO_DESCRIPTION = N_('No description available.')
@@ -104,6 +106,7 @@ class TagVar:
         related_options=None,
         doc_links=None,
         plugin_id=None,
+        plugin_name=None,
     ):
         """
         shortdesc: Short description (typically one or two words) in title case that is suitable
@@ -147,6 +150,7 @@ class TagVar:
         self.related_options = related_options
         self.doc_links = doc_links
         self.plugin_id = plugin_id
+        self.plugin_name = plugin_name
 
     @property
     def shortdesc(self):
@@ -262,7 +266,7 @@ class TagVars(MutableSequence):
         return self.item_from_name(name).item
 
     def script_name_from_name(self, name):
-        tagname, tagdesc, search_name, item = self.item_from_name(name)
+        item = self.tagvar_from_name(name)
         if item:
             return str(item)
         return None
@@ -306,6 +310,11 @@ class TagVars(MutableSequence):
             if self.script_name_from_name(tag):
                 yield f'<a href="#{tag}">%{tag}%</a>'
 
+    def plugin_info(self, item: TagVar):
+        if not item.plugin_name:
+            return
+        yield item.plugin_name
+
     def _base_description(self, item: TagVar):
         return _markdown(_(item.longdesc) if item.longdesc else _(TEXT_NO_DESCRIPTION))
 
@@ -328,7 +337,7 @@ class TagVars(MutableSequence):
 
     def tooltip_content(self, item: TagVar):
         content = self._base_description(item)
-        content += self._add_sections(item, (Section.notes,))
+        content += self._add_sections(item, (Section.notes, Section.plugin_info))
         return content
 
     def full_description_content(self, item: TagVar):
@@ -339,12 +348,7 @@ class TagVars(MutableSequence):
             content += _markdown(_(item.additionaldesc))
 
         # Append additional sections as required
-        include_sections = (
-            Section.notes,
-            Section.options,
-            Section.links,
-            Section.see_also,
-        )
+        include_sections = (Section.notes, Section.options, Section.links, Section.see_also, Section.plugin_info)
         content += self._add_sections(item, include_sections)
 
         return content

--- a/picard/ui/widgets/scriptdocumentation.py
+++ b/picard/ui/widgets/scriptdocumentation.py
@@ -34,17 +34,14 @@ from picard.const.tags import ALL_TAGS
 from picard.extension_points.script_variables import ext_point_script_variables
 from picard.i18n import gettext as _
 from picard.script import script_function_documentation_all
-from picard.tags.docs import (
-    display_plugin_tag_full_description,
-    display_tag_full_description,
-)
+from picard.tags.docs import display_tag_full_description
 from picard.util import get_url
 
 from picard.ui import FONT_FAMILY_MONOSPACE
 from picard.ui.colors import interface_colors
 
 
-DocItem = namedtuple('DocItem', 'name desc plugin')
+DocItem = namedtuple('DocItem', 'name desc')
 
 DOCUMENTATION_HTML_TEMPLATE = '''
 <!DOCTYPE html>
@@ -149,48 +146,35 @@ class FunctionsDocumentationPage(DocumentationPage):
 
 class TagsDocumentationPage(DocumentationPage):
     def generate_html(self):
-        def process_tag(tag_name: str, tag_desc: str, plugin_name: str | None):
+        def process_tag(tag_name: str, tag_desc: str):
             tag_title = f'<a id="{tag_name}"><code>%{tag_name}%</code></a>'
-            if plugin_name:
-                plugin_label = _("Plugin: {plugin_name}").format(plugin_name=plugin_name)
-                tag_desc = f'{tag_desc}[{plugin_label}]'
             return f'<dt>{tag_title}</dt><dd>{tag_desc}</dd>'
-
-        tagger = tagger_instance()
-        manager = tagger.get_plugin_manager() if tagger else None
 
         tags: list[DocItem] = []
 
         # Process system-defined tags and variables
-        for tag_name in [tag.script_name() for tag in ALL_TAGS]:
+        for var in ALL_TAGS:
             tags.append(
                 DocItem(
-                    name=tag_name,
-                    desc=display_tag_full_description(tag_name),
-                    plugin=None,
+                    name=var.script_name(),
+                    desc=display_tag_full_description(var),
                 )
             )
 
         # Process plugin variables separately to allow plugin descriptions for duplicated variables.
         for var in ext_point_script_variables:
-            plugin_name = None
-            if var.plugin_id and manager:
-                plugin = manager.plugin_id_to_plugin(var.plugin_id)
-                if plugin:
-                    plugin_name = plugin.name()
             tags.append(
                 DocItem(
                     name=var.script_name(),
-                    desc=display_plugin_tag_full_description(var.script_name(), var._longdesc),
-                    plugin=plugin_name,
+                    desc=display_tag_full_description(var),
                 )
             )
 
         html = ''
         # Sort tags alphabetically regardless of whether they are hidden, with system tags shown
         # before plugin tags having the same name.
-        for tag in sorted(tags, key=lambda x: (x.name.lstrip('_'), x.plugin or '')):
-            html += process_tag(tag.name, tag.desc, tag.plugin)
+        for tag in sorted(tags, key=lambda x: x.name.lstrip('_')):
+            html += process_tag(tag.name, tag.desc)
 
         return html
 

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -33,7 +33,6 @@ from picard.extension_points import (
     unset_plugin_uuid,
 )
 from picard.extension_points.script_variables import (
-    get_plugin_variable_documentation,
     register_script_variable,
     unregister_all_script_variables,
     unregister_script_variable,
@@ -250,8 +249,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('my_var1', 'some docs')
         register_script_variable('my_var2', 'other docs')
         self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
-        self.assertEqual('some docs', get_plugin_variable_documentation('my_var1'))
         var = self._get_tagvar_by_name('my_var1')
+        self.assertEqual('some docs', var._longdesc)
         self.assertTrue(var.is_tag)
         self.assertFalse(var.is_hidden)
         self.assertFalse(var.is_multi_value)
@@ -259,15 +258,18 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
     def test_register_script_variable_no_docs(self):
         register_script_variable('my_var1')
         self.assertEqual({'my_var1'}, self._registered_variable_names())
-        self.assertIsNone(get_plugin_variable_documentation('my_var1'))
+        var = self._get_tagvar_by_name('my_var1')
+        self.assertIsNone(var._longdesc)
 
     def test_register_script_variable_with_api(self):
         api = self._make_api()
         register_script_variable('my_var1', 'Some docs', api)
         register_script_variable('my_var2', api=api)
         self.assertEqual({'my_var1', 'my_var2'}, self._registered_variable_names())
-        self.assertEqual('Some docs', get_plugin_variable_documentation('my_var1'))
-        self.assertIsNone(get_plugin_variable_documentation('my_var2'))
+        var1 = self._get_tagvar_by_name('my_var1')
+        self.assertEqual('Some docs', var1._longdesc)
+        var2 = self._get_tagvar_by_name('my_var2')
+        self.assertIsNone(var2._longdesc)
 
     def test_register_script_variable_invalid_name(self):
         with self.assertRaises(ValueError):
@@ -305,7 +307,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         # Original registration should remain unchanged
         var = self._get_tagvar_by_name('my_var')
         self.assertFalse(var.is_hidden)
-        self.assertEqual('Non-hidden docs', get_plugin_variable_documentation('my_var'))
+        self.assertEqual('Non-hidden docs', var._longdesc)
 
     def test_register_same_name_hidden_then_non_hidden_rejected(self):
         """Registering non-hidden after hidden with same base name should be rejected."""
@@ -317,7 +319,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         # Original hidden registration should remain unchanged
         var = self._get_tagvar_by_name('my_var')
         self.assertTrue(var.is_hidden)
-        self.assertEqual('Hidden docs', get_plugin_variable_documentation('_my_var'))
+        self.assertEqual('Hidden docs', var._longdesc)
 
     def test_register_script_variable_is_multi_value(self):
         """is_multi_value parameter should be passed through to the TagVar."""
@@ -331,7 +333,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('my_var', 'First docs', api)
         register_script_variable('my_var', 'Updated docs', api)
         self.assertEqual({'my_var'}, self._registered_variable_names())
-        self.assertEqual('Updated docs', get_plugin_variable_documentation('my_var'))
+        var = self._get_tagvar_by_name('my_var')
+        self.assertEqual('Updated docs', var._longdesc)
 
     def test_register_same_variable_different_plugins(self):
         """Same variable name from different plugins should both be kept."""
@@ -340,7 +343,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from plugin1', api1)
         register_script_variable('shared_var', 'Docs from plugin2', api2)
         self.assertEqual({'shared_var'}, self._registered_variable_names())
-        self.assertEqual('Docs from plugin1', get_plugin_variable_documentation('shared_var'))
+        var = self._get_tagvar_by_name('shared_var')
+        self.assertEqual('Docs from plugin1', var._longdesc)
 
     def test_unregister_script_variable(self):
         """Unregistering a single variable should remove only that variable."""
@@ -383,7 +387,8 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         register_script_variable('shared_var', 'Docs from p2', api2)
         unregister_script_variable('shared_var', api1)
         self.assertEqual({'shared_var'}, self._registered_variable_names())
-        self.assertEqual('Docs from p2', get_plugin_variable_documentation('shared_var'))
+        var = self._get_tagvar_by_name('shared_var')
+        self.assertEqual('Docs from p2', var._longdesc)
 
     def test_extension_point_unregister_with_match(self):
         """ExtensionPoint.unregister should remove only items matching the callable."""

--- a/test/test_extension_points.py
+++ b/test/test_extension_points.py
@@ -317,7 +317,7 @@ class TestExtensionPointsScriptVariable(PicardTestCase):
         # Original hidden registration should remain unchanged
         var = self._get_tagvar_by_name('my_var')
         self.assertTrue(var.is_hidden)
-        self.assertEqual('Hidden docs', get_plugin_variable_documentation('my_var'))
+        self.assertEqual('Hidden docs', get_plugin_variable_documentation('_my_var'))
 
     def test_register_script_variable_is_multi_value(self):
         """is_multi_value parameter should be passed through to the TagVar."""

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -26,10 +26,7 @@ import unittest.mock as mock
 
 from test.picardtestcase import PicardTestCase
 
-from picard.const import (
-    DOCS_SERVER_URL,
-    PICARD_URLS,
-)
+from picard.const import PICARD_URLS
 from picard.const.tags import ALL_TAGS
 from picard.options import (
     Option,
@@ -515,54 +512,78 @@ class UtilTagsTest(PicardTestCase):
         self.assertEqual(display_tag_tooltip('performer'), result)
 
     def test_display_tag_full_description(self):
+        item = TagVar(name='my_var', longdesc='The tag description.')
+
+        # Tag with description only
+        expected = "<p>The tag description.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+
+        # Multi-value tag with description only
+        item.is_multi_value = True
+        expected = "<p>The tag description.</p><p><strong>Notes:</strong> multi-value variable.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.is_multi_value = False
+
         # Tag with option setting only
-        if ('setting', 'use_genres') not in Option.registry:
-            Option('setting', 'use_genres', None, title='Use genres from MusicBrainz')
-        result = (
-            '<p><em>%genre%</em></p><p>The specified genre information from MusicBrainz.</p><p><strong>Notes:</strong> multi-value '
-            'variable.</p><p><strong>Option Settings:</strong> Use genres from MusicBrainz.</p>'
-        )
-        self.assertEqual(display_tag_full_description('genre'), result)
+        Option('setting', 'my_script_var_opt', None, title='Option description')
+        item.related_options = ('my_script_var_opt',)
+        expected = "<p>The tag description.</p><p><strong>Option Settings:</strong> Option description.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.related_options = None
 
-        # Tag with link only
-        result = (
-            '<p><em>%barcode%</em></p><p>The barcode assigned to the release.</p>'
-            "<p><strong>Links:</strong> <a href='https://musicbrainz.org/doc/Barcode'>Barcode in MusicBrainz documentation</a>; "
-            "<a href='{server}en/latest/appendices/tag_mapping.html#id6'>Barcode mapping in Picard documentation</a>.</p>"
-        ).format(server=DOCS_SERVER_URL)
-        self.assertEqual(display_tag_full_description('barcode'), result)
+        # Tag with plugin info
+        item.plugin_name = "My Plugin"
+        expected = "<p>The tag description.</p><p><strong>Plugin:</strong> My Plugin.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.plugin_name = None
 
-        # Hidden tag with notes only.
-        result = (
-            '<p><em>%_sample_rate%</em></p><p>The sample rate of the audio file.</p>'
-            '<p><strong>Notes:</strong> preserved read-only; info from audio file; not provided from MusicBrainz data.</p>'
+        # Tag with doc links
+        item.doc_links = (
+            DocumentLink('Link 1', 'https://example.com'),
+            DocumentLink('Link 2', 'https://example.com/foo'),
         )
-        self.assertEqual(display_tag_full_description('_sample_rate'), result)
+        expected = "<p>The tag description.</p><p><strong>Links:</strong> <a href='https://example.com'>Link 1</a>; <a href='https://example.com/foo'>Link 2</a>.</p>"
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.doc_links = None
+
+        # Tag with see also references
+        item.see_also = ('artist', 'albumartist')
+        expected = '<p>The tag description.</p><p><strong>See Also:</strong> <a href="#artist">%artist%</a>; <a href="#albumartist">%albumartist%</a>.</p>'
+        self.assertEqual(display_tag_full_description(item), expected)
+        item.see_also = None
 
         # Tag with complex markdown (list items) and notes.
+        item.is_hidden = True
+        item.is_multi_value = True
+        item._longdesc = """Description of **My Var**:
+
+- Foo
+- Bar
+        """
         result = (
             (
-                '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:</p>\n'
+                '<p>Description of <strong>My Var</strong>:</p>\n'
                 '<ul>\n'
-                '<li>vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;<em>vocal</em>&quot;, '
-                '&quot;<em>guest guitar</em>&quot;, &quot;<em>solo violin</em>&quot;, etc.</li>\n'
-                '<li>the orchestra for the associated release or recording, where &quot;type&quot; is &quot;<em>orchestra</em>&quot;</li>\n'
-                '<li>the concert master for the associated release or recording, where &quot;type&quot; is &quot;<em>concertmaster</em>&quot;</li>\n'
-                '</ul>'
-                '<p><strong>Notes:</strong> multi-value variable.</p>'
+                '<li>Foo</li>\n'
+                '<li>Bar</li>\n'
+                '</ul><p><strong>Notes:</strong> multi-value variable.</p>'
             )
             if markdown is not None
             else (
-                '<p><em>%performer%</em></p><p>The names of the performers for the specified type. These types include:'
-                '<br /><br />'
-                '- vocals or instruments for the associated release or recording, where &quot;type&quot; can be &quot;*vocal*&quot;, '
-                '&quot;*guest guitar*&quot;, &quot;*solo violin*&quot;, etc.<br />'
-                '- the orchestra for the associated release or recording, where &quot;type&quot; is &quot;*orchestra*&quot;<br />'
-                '- the concert master for the associated release or recording, where &quot;type&quot; is &quot;*concertmaster*&quot;</p>'
+                '<p>Description of **My Var**:<br /><br />'
+                '- Foo<br />'
+                '- Bar</p>'
                 '<p><strong>Notes:</strong> multi-value variable.</p>'
             )
         )
-        self.assertEqual(display_tag_full_description('performer'), result)
+        self.assertEqual(display_tag_full_description(item), result)
+        item.is_hidden = False
+        item.is_multi_value = False
+
+        # Tag with no description
+        item._longdesc = None
+        expected = '<p>my_var</p>'
+        self.assertEqual(display_tag_full_description(item), expected)
 
 
 class UtilTagsOptionsTest(PicardTestCase):


### PR DESCRIPTION
- Fix for the script editor tooltip for hidden variables not showing description.
- Refactor script variable documentation formatting for both tooltip and docs to use the same code path for built-in and plugin variables
  - Fixes display of plugin name
  - Remove double display of `%var%`
  - "Plugin" is a documentation section